### PR TITLE
Fix Dib's linked profile URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A modern take on the useful [JFLAP](https://www.jflap.org/)
 ## Contributors
 
 - [Max Reid](https://github.com/Prydeton)
-- [Thomas Dib](https://github.com/s3838765)
+- [Thomas Dib](https://github.com/tdib)
 - [Ewan Breakey](https://github.com/giraugh)
 - [Benji Grant](https://github.com/GRA0007)
 - [Tim Tran](https://github.com/spacediscotqtt)


### PR DESCRIPTION
This is one small step for Max DEBT and one giant leap for Dibanity.