### PR TITLE
Safari doesn't support user-select

### DIFF
--- a/frontend/src/components/GraphView/graphViewStyle.js
+++ b/frontend/src/components/GraphView/graphViewStyle.js
@@ -29,6 +29,7 @@ export const Svg = styled('svg', forwardRef)`
   /* Text */
   text {
     user-select: none;
+    -webkit-user-select: none; /* for safari */
   }
 
   /* Cursors */


### PR DESCRIPTION
Just uses `-webkit-user-select` as well on the svg