### PR TITLE
Add delta into state transition table to reflect course materials

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/Info/Info.js
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.js
@@ -70,7 +70,7 @@ const Info = () => {
       <Table>
         <tbody>
           <tr>
-            <th></th>
+            <th>&delta;</th>
             {alphabet.map(symbol => <th key={symbol}>{symbol}</th>)}
           </tr>
           {resolvedGraph.states.map(state => <tr key={state.id}>


### PR DESCRIPTION
Course materials have the same transition table but contain delta in the corner
![image](https://user-images.githubusercontent.com/79500311/173217726-46687e10-df02-4379-b7d0-b154c6527b05.png)
![image](https://user-images.githubusercontent.com/79500311/173217729-394785f6-432e-4a1b-b5e3-e1ac040b1809.png)
