### PR TITLE
Fix JFLAP Importing

### DIFF
--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -6,6 +6,7 @@ import { VIEW_MOVE_STEP, SCROLL_MAX, SCROLL_MIN } from '/src/config/interactions
 import { convertJFLAPXML } from '@automatarium/jflap-translator'
 import { haveInputFocused } from '/src/util/actions'
 import { dispatchCustomEvent } from '/src/util/events'
+import { createNewProject } from '../stores/useProjectStore'
 
 const isWindows = navigator.platform.match(/Win/)
 const formatHotkey = ({ key, meta, alt, shift, showCtrl = isWindows }) => [
@@ -378,10 +379,13 @@ const promptLoadFile = (parse, onData, errorMessage='Failed to parse file') => {
   input.onchange = () => {
     // Read file data
     const reader = new FileReader()
-    reader.onloadend = () => {
+    reader.onloadend = () => { 
       try {
         const data = parse(reader.result)
-        onData(data)
+        onData({
+          ...createNewProject(),
+          ...data
+        } )
       } catch (error) {
         window.alert(errorMessage)
         console.error(error)

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -381,11 +381,18 @@ const promptLoadFile = (parse, onData, errorMessage='Failed to parse file') => {
     const reader = new FileReader()
     reader.onloadend = () => { 
       try {
-        const data = parse(reader.result)
-        onData({
+        const fileData = parse(reader.result)
+        const project = {
           ...createNewProject(),
-          ...data
-        } )
+          ...fileData,
+        }
+        onData({
+          ...project,
+          meta: {
+            ...project.meta,
+            name: input.files[0]?.name.split('.').slice(0, -1).join('.')
+          }
+        })
       } catch (error) {
         window.alert(errorMessage)
         console.error(error)

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -394,7 +394,7 @@ const promptLoadFile = (parse, onData, errorMessage='Failed to parse file') => {
           }
         })
       } catch (error) {
-        window.alert(errorMessage)
+        window.alert(errorMessage + '\n' + error)
         console.error(error)
       }
     }

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -394,7 +394,7 @@ const promptLoadFile = (parse, onData, errorMessage='Failed to parse file') => {
           }
         })
       } catch (error) {
-        window.alert(errorMessage + '\n' + error)
+        window.alert(`${errorMessage}\n${error}`)
         console.error(error)
       }
     }

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -6,7 +6,7 @@ import { VIEW_MOVE_STEP, SCROLL_MAX, SCROLL_MIN } from '/src/config/interactions
 import { convertJFLAPXML } from '@automatarium/jflap-translator'
 import { haveInputFocused } from '/src/util/actions'
 import { dispatchCustomEvent } from '/src/util/events'
-import { createNewProject } from '../stores/useProjectStore'
+import { createNewProject } from '/src/stores/useProjectStore'
 
 const isWindows = navigator.platform.match(/Win/)
 const formatHotkey = ({ key, meta, alt, shift, showCtrl = isWindows }) => [

--- a/packages/jflap-translator/src/convertJFLAP.js
+++ b/packages/jflap-translator/src/convertJFLAP.js
@@ -26,9 +26,9 @@ export const convertJFLAPProject = jflapProject => {
   }
 
   // Convert attributes to arrays if they are not already
-  states === undefined ? [] : Array.isArray(states) ? states : [states]
-  transitions === undefined ? [] : Array.isArray(transitions) ? transitions : [transitions]
-  notes === undefined ? [] : Array.isArray(notes) ? notes : [notes]
+  states = states === undefined ? [] : (Array.isArray(states) ? states : [states])
+  transitions = transitions === undefined ? [] : (Array.isArray(transitions) ? transitions : [transitions])
+  notes = notes === undefined ? [] : (Array.isArray(notes) ? notes : [notes])
 
   // Find initial state
   const initialState = states.find(s => s.initial)

--- a/packages/jflap-translator/src/convertJFLAP.js
+++ b/packages/jflap-translator/src/convertJFLAP.js
@@ -9,7 +9,6 @@ export const convertJFLAPXML = xml => {
   const jflapProject = JSON.parse(json)
   return convertJFLAPProject(jflapProject)
 }
-// window.convertJFLAPXML = convertJFLAPXML
 
 // Convert JFLAP JSON to Automatarium format
 export const convertJFLAPProject = jflapProject => {

--- a/packages/jflap-translator/src/convertJFLAP.js
+++ b/packages/jflap-translator/src/convertJFLAP.js
@@ -27,9 +27,9 @@ export const convertJFLAPProject = jflapProject => {
   }
 
   // Convert attributes to arrays if they are not already
-  states = Array.isArray(states) ? states : [states]
-  transitions = Array.isArray(transitions) ? transitions : [transitions]
-  notes = Array.isArray(notes) ? notes : [notes]
+  states === undefined ? [] : Array.isArray(states) ? states : [states]
+  transitions === undefined ? [] : Array.isArray(transitions) ? transitions : [transitions]
+  notes === undefined ? [] : Array.isArray(notes) ? notes : [notes]
 
   // Find initial state
   const initialState = states.find(s => s.initial)


### PR DESCRIPTION
For the most part appears to be broken
- Imported .jff files with one state, transition or comment would cause an issue because they would be represented as [undefined] and then try to be mapped: this should no longer put undefined in an array
- When a .jff file was imported while inside a file it would override the existing project in the store (including necessary metadata), preventing the ability to open testing lab and saving the file: fixed by first creating a new project and then spreading the imported file properties -- **I feel like this isn't the way to go but it allows for importing**

~~Side note: importing a JFLAP project of a different type (e.g. TM) gives an alert window of a message determined by us (first image below), but the console errors something a little clearer (second image). Wondering if it would be worth replacing the alert content with the thrown error or could there be some wacky errors?~~

