### PR TITLE
Use project name as downloaded file name

### DIFF
--- a/frontend/src/components/GraphView/hooks/useImageExport.js
+++ b/frontend/src/components/GraphView/hooks/useImageExport.js
@@ -31,7 +31,7 @@ const useImageExport = svgRef => {
 
       // Setup download link
       const link = document.createElement('a')
-      link.download = `${projectName.replace(/[\s]/g, '_').replace(/[#%&{}\\<>*?/$!'":@+`|=]/g, '')}.${e.detail.type}`
+      link.download = `${projectName.replace(/[#%&{}\\<>*?/$!'":@+`|=]/g, '')}.${e.detail.type}`
 
       // Export SVG
       if (e.detail.type === 'svg') {

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -70,18 +70,15 @@ const useActions = (registerHotkeys=false) => {
     SAVE_FILE_AS: {
       hotkey: { key: 's', shift: true, meta: true },
       handler: () => {
-        const fileName = window.prompt('What would you like to name this automaton?') // TODO: better prompt
-        if (fileName) {
-          // Pull project state
-          const { project } = useProjectStore.getState()
+        // Pull project state
+        const { project } = useProjectStore.getState()
 
-          // Create a download link and use it
-          const a = document.createElement('a')
-          const file = new Blob([JSON.stringify(project, null, 2)], {type: 'application/json'})
-          a.href = URL.createObjectURL(file)
-          a.download = fileName // TODO: prompt file location - might not be possible?
-          a.click()
-        }
+        // Create a download link and use it
+        const a = document.createElement('a')
+        const file = new Blob([JSON.stringify(project, null, 2)], {type: 'application/json'})
+        a.href = URL.createObjectURL(file)
+        a.download = project.meta.name // TODO: prompt file location - might not be possible?
+        a.click()
       },
     },
     EXPORT_AS_PNG: {

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -77,7 +77,7 @@ const useActions = (registerHotkeys=false) => {
         const a = document.createElement('a')
         const file = new Blob([JSON.stringify(project, null, 2)], {type: 'application/json'})
         a.href = URL.createObjectURL(file)
-        a.download = project.meta.name // TODO: prompt file location - might not be possible?
+        a.download = project.meta.name.replace(/[#%&{}\\<>*?/$!'":@+`|=]/g, '') // TODO: prompt file location - might not be possible?
         a.click()
       },
     },


### PR DESCRIPTION
Instead of prompting the user for a name when saving an automaton, it automatically names it based on the project name.

This is far more streamlined because they 1) don't have to type anything, 2) likely already have the project named what they'd want the file to be called.

In the worst case they can rename the file once it's downloaded but I believe the majority of the time they'll have it named properly.

Like if you agree