### PR TITLE
Fix/comment text

### DIFF
--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -31,6 +31,7 @@
   --selection-fill-light: #00000020;
   --state-bg-light: hsl(var(--primary-h) var(--primary-s) 75%);
   --state-bg-selected-light: hsl(var(--primary-h) 70% 65%);
+  --comment-text-light: var(--black);
 
   /* Dark */
   --grid-bg-dark: #1B1B1B;
@@ -39,6 +40,7 @@
   --selection-fill-dark: #FFFFFF20;
   --state-bg-dark: hsl(var(--primary-h) 47% 33%);
   --state-bg-selected-dark: hsl(var(--primary-h) 65% 23%);
+  --comment-text-dark: var(--white);
 
   --grid-bg: var(--grid-bg-light);
   --grid-dot: var(--grid-dot-light);
@@ -46,7 +48,7 @@
   --selection-fill: var(--selection-fill-light);
   --state-bg: var(--state-bg-light);
   --state-bg-selected: var(--state-bg-selected-light);
-  --comment-text: var(--stroke-light);
+  --comment-text: var(--comment-text-light);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -57,7 +59,7 @@
     --selection-fill: var(--selection-fill-dark);
     --state-bg: var(--state-bg-dark);
     --state-bg-selected: var(--state-bg-selected-dark);
-    --comment-text: var(--white);
+    --comment-text: var(--comment-text-dark);
   }
 }
 
@@ -68,7 +70,7 @@ body.light, body.light #automatarium-graph {
   --selection-fill: var(--selection-fill-light);
   --state-bg: var(--state-bg-light);
   --state-bg-selected: var(--state-bg-selected-light);
-  --comment-text: var(--stroke-light);
+  --comment-text: var(--comment-text-light);
 }
 body.dark, body.dark #automatarium-graph {
   --grid-bg: var(--grid-bg-dark);
@@ -77,7 +79,7 @@ body.dark, body.dark #automatarium-graph {
   --selection-fill: var(--selection-fill-dark);
   --state-bg: var(--state-bg-dark);
   --state-bg-selected: var(--state-bg-selected-dark);
-  --comment-text: var(--white);
+  --comment-text: var(--comment-text-dark);
 }
 
 body {

--- a/frontend/public/style.css
+++ b/frontend/public/style.css
@@ -46,6 +46,7 @@
   --selection-fill: var(--selection-fill-light);
   --state-bg: var(--state-bg-light);
   --state-bg-selected: var(--state-bg-selected-light);
+  --comment-text: var(--stroke-light);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -56,6 +57,7 @@
     --selection-fill: var(--selection-fill-dark);
     --state-bg: var(--state-bg-dark);
     --state-bg-selected: var(--state-bg-selected-dark);
+    --comment-text: var(--white);
   }
 }
 
@@ -66,6 +68,7 @@ body.light, body.light #automatarium-graph {
   --selection-fill: var(--selection-fill-light);
   --state-bg: var(--state-bg-light);
   --state-bg-selected: var(--state-bg-selected-light);
+  --comment-text: var(--stroke-light);
 }
 body.dark, body.dark #automatarium-graph {
   --grid-bg: var(--grid-bg-dark);
@@ -74,6 +77,7 @@ body.dark, body.dark #automatarium-graph {
   --selection-fill: var(--selection-fill-dark);
   --state-bg: var(--state-bg-dark);
   --state-bg-selected: var(--state-bg-selected-dark);
+  --comment-text: var(--white);
 }
 
 body {

--- a/frontend/src/components/CommentRect/CommentRect.js
+++ b/frontend/src/components/CommentRect/CommentRect.js
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react'
 
 import { dispatchCustomEvent } from '/src/util/events'
-import { useSelectionStore } from '/src/stores'
+import { useSelectionStore, useViewStore } from '/src/stores'
 
 import { commentStyles, commentSelectedStyles } from './commentRectStyle'
 
@@ -10,16 +10,17 @@ const CommentRect = ({ id, x, y, text }) => {
   const [size, setSize] = useState({ height: 150, width: 255 })
   const selectedComments = useSelectionStore(s => s.selectedComments)
   const selected = selectedComments.includes(id)
+  const scale = useViewStore(s => s.scale)
 
   useEffect(() => {
     if (containerRef.current) {
       const bounds = containerRef.current.getBoundingClientRect()
       setSize({
-        height: bounds.height,
-        width: bounds.width,
+        height: bounds.height*scale,
+        width: bounds.width*scale,
       })
     }
-  }, [containerRef?.current, text])
+  }, [containerRef?.current, text, scale])
 
   const handleMouseDown = e =>
     dispatchCustomEvent('comment:mousedown', {

--- a/frontend/src/components/CommentRect/commentRectStyle.js
+++ b/frontend/src/components/CommentRect/commentRectStyle.js
@@ -9,7 +9,6 @@ export const commentStyles = {
   userSelect: 'none',
   width: 'max-content',
   maxWidth: '255px',
-  margin: 'auto',
   boxSizing: 'border-box',
 }
 

--- a/frontend/src/components/CommentRect/commentRectStyle.js
+++ b/frontend/src/components/CommentRect/commentRectStyle.js
@@ -1,7 +1,7 @@
 export const commentStyles = {
-  color: 'var(--stroke)',
+  color: 'var(--comment-text)',
   background: 'var(--grid-bg)',
-  padding: '1em',
+  padding: '.8em 1em',
   borderRadius: '.5rem',
   borderWidth: '2.5px',
   borderStyle: 'solid',


### PR DESCRIPTION
Fixes #190

So turns out there _was_ a problem causing #164, the comment bounding box didn't take the zoom into account when calculating its size, so if you edited a comment or opened a project at a different zoom, they would be clipped or have a larger bounding box.

I've fixed this by taking the zoom into account when setting the comment bounding box.

This PR also makes the comment text white in dark mode.