### PR TITLE
Allow panning view with touchpad

### DIFF
--- a/frontend/src/components/CommentRect/CommentRect.js
+++ b/frontend/src/components/CommentRect/CommentRect.js
@@ -20,7 +20,7 @@ const CommentRect = ({ id, x, y, text }) => {
         width: bounds.width*scale,
       })
     }
-  }, [containerRef?.current, text, scale])
+  }, [containerRef?.current, text, scale, x, y])
 
   const handleMouseDown = e =>
     dispatchCustomEvent('comment:mousedown', {

--- a/frontend/src/components/GraphView/hooks/useViewDragging.js
+++ b/frontend/src/components/GraphView/hooks/useViewDragging.js
@@ -12,7 +12,7 @@ const useViewDragging = containerRef => {
   const viewPosition = useViewStore(s => s.position)
   const viewScale = useViewStore(s => s.scale)
   const setViewPosition = useViewStore(s => s.setViewPosition)
-  const setViewScale = useViewStore(s => s.setViewScale)
+  const setViewPositionAndScale = useViewStore(s => s.setViewPositionAndScale)
 
   // Keep track of drag events
   const [dragStartPosition, setDragStartPosition] = useState(null)
@@ -35,19 +35,27 @@ const useViewDragging = containerRef => {
     e.stopPropagation()
     e.preventDefault()
 
-    // Determine scroll amount and whether its possible
-    const desiredScrollAmount = e.deltaY * SCROLL_SPEED / 5
-    const newScale = Math.min(SCROLL_MAX, Math.max(SCROLL_MIN, viewScale + desiredScrollAmount))
-    const scrollAmount = newScale - viewScale
-    if (scrollAmount === 0)
-      return
+    // Do zoom
+    if (e.ctrlKey) {
+      // Determine scroll amount and whether its possible
+      const desiredScrollAmount = e.deltaY * SCROLL_SPEED * viewScale
+      const newScale = Math.min(SCROLL_MAX, Math.max(SCROLL_MIN, viewScale + desiredScrollAmount))
+      const scrollAmount = newScale - viewScale
+      if (scrollAmount === 0)
+        return
 
-    const [mx, my] = relativeMousePosition(e.clientX, e.clientY)
-    setViewPosition({
-      x: viewPosition.x - mx * scrollAmount,
-      y: viewPosition.y - my * scrollAmount,
-    })
-    setViewScale(newScale)
+      const [mx, my] = relativeMousePosition(e.clientX, e.clientY)
+      setViewPositionAndScale({
+        x: viewPosition.x - mx * scrollAmount,
+        y: viewPosition.y - my * scrollAmount,
+      }, newScale)
+    } else {
+      // Pan
+      setViewPosition({
+        x: viewPosition.x + e.deltaX * viewScale,
+        y: viewPosition.y + e.deltaY * viewScale,
+      })
+    }
   }, [viewScale, viewPosition], {
     options: { passive: false }
   })

--- a/frontend/src/components/SelectionBox/SelectionBox.js
+++ b/frontend/src/components/SelectionBox/SelectionBox.js
@@ -90,6 +90,8 @@ const SelectionBox = () => {
     fill='var(--selection-fill)'
     stroke='var(--stroke)'
     strokeWidth='1.75'
+    rx={3}
+    ry={3}
   />
 }
 

--- a/frontend/src/config/interactions.js
+++ b/frontend/src/config/interactions.js
@@ -2,5 +2,5 @@ export const GRID_SNAP = 15
 export const VIEW_MOVE_STEP = 15
 export const SCROLL_MAX = 3
 export const SCROLL_MIN = 0.2
-export const SCROLL_SPEED = 0.02
+export const SCROLL_SPEED = 0.008
 

--- a/frontend/src/pages/Editor/Editor.js
+++ b/frontend/src/pages/Editor/Editor.js
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 import { useAutosaveProject, useSyncCurrentProject, useActions, useEvent } from '/src/hooks'
-import { useToolStore, useProjectStore, useExportStore } from '/src/stores'
+import { useToolStore, useProjectStore, useExportStore, useViewStore } from '/src/stores'
 import { haveInputFocused } from '/src/util/actions'
 import { Menubar, Sidepanel, Toolbar, EditorPanel, Spinner } from '/src/components'
 import { Preferences, ShortcutGuide, ExportImage } from '/src/pages'
@@ -16,6 +16,7 @@ const Editor = () => {
   const [showPreferencesModal, setShowPreferencesModal] = useState(false)
   const [showShortcutGuide, setShowShortcutGuide] = useState(false)
   const resetExportSettings = useExportStore(s => s.reset)
+  const setViewPositionAndScale = useViewStore(s => s.setViewPositionAndScale)
 
   // Syncronize last-opened project with backend before showing it
   const loading = useSyncCurrentProject()
@@ -32,6 +33,7 @@ const Editor = () => {
       navigate('/new')
     }
     resetExportSettings()
+    setViewPositionAndScale({x: 0, y:0}, 1)
   }, [])
 
   // Change tool when holding certain keys

--- a/frontend/src/stores/useViewStore.js
+++ b/frontend/src/stores/useViewStore.js
@@ -15,7 +15,7 @@ const canvasToScreenSpace = (x, y, container) => {
 
 
 const useViewStore = create((set, get) => ({
-  svgElement: null, 
+  svgElement: null,
   position: { x: 0, y: 0 },
   size: { width: 0, height: 0},
   scale: 1,
@@ -27,6 +27,7 @@ const useViewStore = create((set, get) => ({
   setViewSize: size => set({ size }),
   setViewScale: scale => set({ scale }),
   setSvgElement: svgElement => set({ svgElement }),
+  setViewPositionAndScale: (position, scale) => set({ position, scale }),
 
   /* Apply the view transform to a point */
   applyView: (x, y) =>


### PR DESCRIPTION
Mouse users must now hold ctrl to zoom with the scroll wheel. This also fixes the position slipping while zooming occasionally, an issue that was caused due to the position and zoom being set separately while zooming.