### PR TITLE
Refactor padding to margin

### DIFF
--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -33,7 +33,6 @@ const useActions = (registerHotkeys=false) => {
   const upsertProject = useProjectsStore(s => s.upsertProject)
   const moveView = useViewStore(s => s.moveViewPosition)
   const createState = useProjectStore(s => s.createState)
-  const updateState = useProjectStore(s => s.updateState)
   const screenToViewSpace = useViewStore(s => s.screenToViewSpace)
   const setTool = useToolStore(s => s.setTool)
 

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -162,7 +162,7 @@ const useActions = (registerHotkeys=false) => {
         // Get state
         const view = useViewStore.getState()
 
-        // Padding around view
+        // Margin around view
         const border = 40
 
         // Get the bounding box of the SVG group

--- a/frontend/src/hooks/useImageExport.js
+++ b/frontend/src/hooks/useImageExport.js
@@ -34,7 +34,7 @@ export const svgToCanvas = ({ height, width, svg }) => new Promise(resolve => {
 
 // Extract the SVG graph as a string
 export const getSvgString = ({
-  padding = 20,
+  margin = 20,
   background = 'none',
   color,
   darkMode = false,
@@ -45,8 +45,8 @@ export const getSvgString = ({
 
   // Set viewbox
   const b = document.querySelector('#automatarium-graph > g').getBBox()
-  padding = Number(padding ?? 0)+1
-  const [x, y, width, height] = [b.x - padding, b.y - padding, b.width + padding*2, b.height + padding*2]
+  margin = Number(margin ?? 0)+1
+  const [x, y, width, height] = [b.x - margin, b.y - margin, b.width + margin*2, b.height + margin*2]
   clonedSvgElement.setAttribute('viewBox', `${x} ${y} ${width} ${height}`)
 
   // If changing colour, save what is on the actual svg, then change them temporarily

--- a/frontend/src/pages/ExportImage/ExportImage.js
+++ b/frontend/src/pages/ExportImage/ExportImage.js
@@ -112,7 +112,7 @@ const ExportImage = () => {
           </Preference>
           {type === 'svg' && <span style={{ fontSize: '.7em', display: 'block', maxWidth: 'fit-content', color: 'var(--error)' }}>Note: SVG exporting is still in beta and may not work as expected</span>}
           <Preference label="Margin" fullWidth>
-            <Input type="number" small value={margin} onChange={e => setOptions({ margin: e.target.value })} />
+            <Input type="number" min="0" max="500" small value={margin} onChange={e => setOptions({ margin: e.target.value === '' ? e.target.value : Math.min(Math.max(e.target.value, 0), 500) })} />
           </Preference>
           <Preference label="Accent colour" fullWidth>
             <Input type="select" small value={color} onChange={e => setOptions({ color: e.target.value })}>

--- a/frontend/src/pages/ExportImage/ExportImage.js
+++ b/frontend/src/pages/ExportImage/ExportImage.js
@@ -8,7 +8,7 @@ import { Wrapper, Image } from './exportImageStyle'
 
 const ExportImage = () => {
   const { exportVisible, setExportVisible, options, setOptions } = useExportStore()
-  const { filename, type, padding, color, darkMode, background } = options
+  const { filename, type, margin, color, darkMode, background } = options
   const projectName = useProjectStore(s => s.project?.meta.name)
   const projectColor = useProjectStore(s => s.project?.config.color)
   const [svg, setSvg] = useState()
@@ -25,10 +25,10 @@ const ExportImage = () => {
   // Set svg
   useEffect(() => {
     if (!exportVisible) return
-    const { height, width, svg } = getSvgString({ padding, background, color, darkMode })
+    const { height, width, svg } = getSvgString({ margin, background, color, darkMode })
     setSvg(svg)
     setSize({ height, width })
-  }, [padding, color, darkMode, background, exportVisible])
+  }, [margin, color, darkMode, background, exportVisible])
 
   useEffect(() => {
     if (type === 'svg') {
@@ -111,8 +111,8 @@ const ExportImage = () => {
             </Input>
           </Preference>
           {type === 'svg' && <span style={{ fontSize: '.7em', display: 'block', maxWidth: 'fit-content', color: 'var(--error)' }}>Note: SVG exporting is still in beta and may not work as expected</span>}
-          <Preference label="Padding" fullWidth>
-            <Input type="number" small value={padding} onChange={e => setOptions({ padding: e.target.value })} />
+          <Preference label="Margin" fullWidth>
+            <Input type="number" small value={margin} onChange={e => setOptions({ margin: e.target.value })} />
           </Preference>
           <Preference label="Accent colour" fullWidth>
             <Input type="select" small value={color} onChange={e => setOptions({ color: e.target.value })}>

--- a/frontend/src/stores/useExportStore.js
+++ b/frontend/src/stores/useExportStore.js
@@ -3,7 +3,7 @@ import create from 'zustand'
 const defaultOptions = {
   filename: '',
   type: 'png',
-  padding: 20,
+  margin: 20,
   color: '',
   darkMode: false,
   background: 'solid',


### PR DESCRIPTION
Image exporting options now use the word "margin" instead of padding.

This PR also constrains the margin between `0` and `500` to prevent larger images from being generated (which may crash the system).