### PR TITLE
Info panel state names fix

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/Info/Info.js
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.js
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useCallback } from 'react'
 import { validTransitions, resolveGraph, closureWithPredicate } from '@automatarium/simulation'
 
 import { useProjectStore } from '/src/stores'
@@ -7,11 +7,17 @@ import { Table, SectionLabel } from '/src/components'
 import { Wrapper, Symbol, SymbolList } from './infoStyle'
 
 const Info = () => {
-  const statePrefix = useProjectStore(s => s.project?.config?.statePrefix) ?? 'q'
-  const states = useProjectStore(s => s.project?.states) ?? []
-  const transitions = useProjectStore(s => s.project?.transitions) ?? []
+  const statePrefix = useProjectStore(s => s.project?.config?.statePrefix)
+  const states = useProjectStore(s => s.project?.states)
+  const transitions = useProjectStore(s => s.project?.transitions)
   const initialState = useProjectStore(s => s.project?.initialState)
-  const graph = { states, transitions, initialState }
+  const graph = { states, transitions: transitions ?? [], initialState }
+
+  // Function to get name of state from an id
+  const getStateName = useCallback(id =>
+    graph.states.find(s => s.id === id)?.name || `${statePrefix ?? 'q'}${id}`,
+    [graph.states, statePrefix]
+  )
 
   // Resolve graph
   const resolvedGraph = useMemo(() => resolveGraph(graph), [graph])
@@ -27,7 +33,7 @@ const Info = () => {
 
   const transitionMap = useMemo(() => {
     let map = {} // (ID, Symbol) -> ID[]
-    for (let state of states) {
+    for (let state of states ?? []) {
       for (let symbol of alphabet) {
         const transitions = validTransitions(resolvedGraph, state.id, symbol)
         for (let { transition } of transitions) {
@@ -47,6 +53,7 @@ const Info = () => {
 
     return map
   }, [states, alphabet, resolvedGraph])
+  console.log(transitionMap);
 
   return <>
     <SectionLabel>Alphabet</SectionLabel>
@@ -64,12 +71,12 @@ const Info = () => {
             <th>&delta;</th>
             {alphabet.map(symbol => <th key={symbol}>{symbol}</th>)}
           </tr>
-          {resolvedGraph.states.map(state => <tr key={state.id}>
-            <th>{statePrefix}{state.id}</th>
+          {resolvedGraph.states?.map(state => <tr key={state.id}>
+            <th>{getStateName(state.id)}</th>
             {alphabet.map(symbol => <td key={symbol}>
               {Object.entries(transitionMap)
                 .filter(([key]) => key.split(',')[0] == state.id && key.split(',')[1] == symbol)
-                .map(([, states]) => states.map(s => `${statePrefix}${s}`).join(', '))[0] ?? '-'}
+                .map(([, states]) => states.map(id => getStateName(id)).join(', '))[0] ?? '-'}
             </td>)}
           </tr>)}
         </tbody>
@@ -85,8 +92,8 @@ const Info = () => {
             <th> &delta;(Q &times; &Sigma;) </th>
           </tr>
           {Object.entries(transitionMap).map(([key, states]) => <tr key={key}>
-            <td>({statePrefix}{key.split(',')[0]}, {key.split(',')[1]})</td>
-            <td>{`{${states.sort().map(s => `${statePrefix}${s}`).join(',')}}`}</td>
+            <td>({getStateName(Number(key.split(',')[0]))}, {key.split(',')[1]})</td>
+            <td>{`{${states.sort().map(id => getStateName(id)).join(',')}}`}</td>
           </tr>)}
         </tbody>
       </Table>

--- a/frontend/src/components/Sidepanel/Panels/Info/Info.js
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.js
@@ -56,22 +56,6 @@ const Info = () => {
       </SymbolList>
     </Wrapper>
 
-    <SectionLabel>Transition Function</SectionLabel>
-    <Wrapper>
-      <Table>
-        <tbody>
-          <tr>
-            <th>Q &times; &Sigma;</th>
-            <th> &delta;(Q &times; &Sigma;) </th>
-          </tr>
-          {Object.entries(transitionMap).map(([key, states]) => <tr key={key}>
-            <td>({statePrefix}{key.split(',')[0]}, {key.split(',')[1]})</td>
-            <td>{`{${states.sort().map(s => `${statePrefix}${s}`).join(',')}}`}</td>
-          </tr>)}
-        </tbody>
-      </Table>
-    </Wrapper>
-
     <SectionLabel>State Transition Table</SectionLabel>
     <Wrapper>
       <Table>
@@ -87,6 +71,22 @@ const Info = () => {
                 .filter(([key]) => key.split(',')[0] == state.id && key.split(',')[1] == symbol)
                 .map(([, states]) => states.map(s => `${statePrefix}${s}`).join(', '))[0] ?? '-'}
             </td>)}
+          </tr>)}
+        </tbody>
+      </Table>
+    </Wrapper>
+
+    <SectionLabel>Transition Function</SectionLabel>
+    <Wrapper>
+      <Table>
+        <tbody>
+          <tr>
+            <th>Q &times; &Sigma;</th>
+            <th> &delta;(Q &times; &Sigma;) </th>
+          </tr>
+          {Object.entries(transitionMap).map(([key, states]) => <tr key={key}>
+            <td>({statePrefix}{key.split(',')[0]}, {key.split(',')[1]})</td>
+            <td>{`{${states.sort().map(s => `${statePrefix}${s}`).join(',')}}`}</td>
           </tr>)}
         </tbody>
       </Table>

--- a/frontend/src/components/Sidepanel/Panels/Info/Info.js
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.js
@@ -53,7 +53,6 @@ const Info = () => {
 
     return map
   }, [states, alphabet, resolvedGraph])
-  console.log(transitionMap);
 
   return <>
     <SectionLabel>Alphabet</SectionLabel>


### PR DESCRIPTION
- The transition function and table have been swapped - the function increases in size a lot longer and I've found myself most frequently accessing the table
- The state names are now shown instead of the ids (to reflect any renamed states)

An image of the updates are shown below:
<img src="https://user-images.githubusercontent.com/79500311/178533080-f2ff7c4b-4a4e-4659-9479-18e081e5d108.png" height=500px />

Closes #243 