### PR TITLE
Fix zoom bug (single scroll takes user to 500%)

### DIFF
--- a/frontend/src/components/GraphView/hooks/useViewDragging.js
+++ b/frontend/src/components/GraphView/hooks/useViewDragging.js
@@ -40,7 +40,7 @@ const useViewDragging = containerRef => {
     // Do zoom
     if (ctrlZoom ? e.ctrlKey : true) {
       // Determine scroll amount and whether its possible
-      const desiredScrollAmount = e.deltaY * SCROLL_SPEED * viewScale
+      const desiredScrollAmount = e.deltaY * SCROLL_SPEED
       const newScale = Math.min(SCROLL_MAX, Math.max(SCROLL_MIN, viewScale + desiredScrollAmount))
       const scrollAmount = newScale - viewScale
       if (scrollAmount === 0)


### PR DESCRIPTION
This PR (hopefully) fixes the zoom bug where a single scroll takes the user from x% zoom to 500%. This works on my system but I'm almost certain something is going to break on the MacOS end so check it ty :^)

(pls) Fixes #240 