### PR TITLE
Override right click default behaviour

### DIFF
--- a/frontend/src/components/Dropdown/Dropdown.js
+++ b/frontend/src/components/Dropdown/Dropdown.js
@@ -82,6 +82,7 @@ const Dropdown = ({
 
   return (
     <Wrapper
+      onContextMenu={e => e.preventDefault()}
       $subMenu={subMenu}
       $visible={visible}
       ref={dropdownRef}


### PR DESCRIPTION
Right clicking twice on the canvas will no longer open the default right click menu.
Fixes #254 