### PR TITLE
Select the right simulation function when running multi trace

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
@@ -141,20 +141,16 @@ const TestingLab = () => {
     return `${transitionsWithRejected.join('\n')}${(traceIdx === transitionCount) ? '\n\n' + (accepted ? 'ACCEPTED' : 'REJECTED') : ''}`
   }, [traceInput, simulationResult, statePrefix, traceIdx, getStateName])
 
-  useEffect(() => {
-    if (projectType === 'TM') {
-      setMultiTraceOutput(multiTraceInput.map(input => simulateTM(graph,
-        { pointer: 0, trace: [input] })))
-    } else {
-      setMultiTraceOutput(multiTraceInput.map(input => simulateFSA(graph, input)))
-    }
-  }, [])
 
   useEffect(() => {
     simulateGraph()
     setMultiTraceOutput()
     setTraceIdx(0)
   }, [lastChangeDate])
+  
+  useEffect(() => {
+    setMultiTraceOutput(multiTraceInput.map(input => runSimulation(input)))
+  }, [])
 
   // Set the trace IDx to be passed through store to TMTapeLab component
   useEffect(() => {

--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
@@ -59,8 +59,7 @@ const TestingLab = () => {
       const tapeTrace = input ? input.split('') : ['']
       const tapePointer = 0 // This is hard coded for now. Future development available
 
-      const { halted, trace, tape } = simulateTM(graph, { pointer: tapePointer, trace: tapeTrace } ??
-            { pointer: 0, trace: [] })
+      const { halted, trace, tape } = simulateTM(graph, { pointer: tapePointer, trace: tapeTrace })
 
       return {
         halted,

--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
@@ -94,6 +94,11 @@ const TestingLab = () => {
     }
   }
 
+  /** Runs all multi trace inputs and updates the output */
+  const rerunMultiTraceInput = () => {
+    setMultiTraceOutput(multiTraceInput.map(input => runSimulation(input)))
+  }
+
   // Execute graph
   const simulateGraph = useCallback(() => {
     const result = runSimulation(traceInput)
@@ -141,15 +146,14 @@ const TestingLab = () => {
     return `${transitionsWithRejected.join('\n')}${(traceIdx === transitionCount) ? '\n\n' + (accepted ? 'ACCEPTED' : 'REJECTED') : ''}`
   }, [traceInput, simulationResult, statePrefix, traceIdx, getStateName])
 
-
   useEffect(() => {
     simulateGraph()
     setMultiTraceOutput()
     setTraceIdx(0)
   }, [lastChangeDate])
-  
+
   useEffect(() => {
-    setMultiTraceOutput(multiTraceInput.map(input => runSimulation(input)))
+    rerunMultiTraceInput()
   }, [])
 
   // Set the trace IDx to be passed through store to TMTapeLab component
@@ -309,7 +313,7 @@ const TestingLab = () => {
                   if (e.key === 'Enter' && !e.repeat) {
                     if (e.metaKey || e.ctrlKey) {
                       // Run shortcut
-                      setMultiTraceOutput(multiTraceInput.map(input => simulateFSA(graph, input)))
+                      rerunMultiTraceInput()
                     } else {
                       addMultiTraceInput()
                       window.setTimeout(() => e.target.closest('div').parentElement?.querySelector('div:last-of-type > input')?.focus(), 50)
@@ -358,7 +362,7 @@ const TestingLab = () => {
             icon={<Plus />}
           />
           <Button onClick={() => {
-            setMultiTraceOutput(multiTraceInput.map(input => runSimulation(input)))
+            rerunMultiTraceInput()
           }}>Run</Button>
       </Wrapper>
     </>


### PR DESCRIPTION
Closes #273 

The issue before was that in some places the `if` statements didn't properly switch between FSAs, PDAs. and TMs and some places didn't have any branching and just also simulated FSAs

This PR adds `runSimulation` which runs a provided input with the correct simulation function depending on the `projectType`