### PR TITLE
Use `actions/setup-node` to cache yarn dependencies

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
       - name: Install Yarn Dependencies
         run: yarn
 


### PR DESCRIPTION
This should reduce the time that CI takes (~1.5 minutes is spent just getting dependencies)