### PR TITLE
Add other groups to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,33 @@ Automatarium is a modern take on the useful [JFLAP](https://www.jflap.org/), but
 
 ## Contributors
 
-Automatarium was built by RMIT students
+Automatarium is built by RMIT students with the original members being
 
 - [Max Reid](https://github.com/Prydeton)
 - [Thomas Dib](https://github.com/tdib)
 - [Ewan Breakey](https://github.com/giraugh)
 - [Benji Grant](https://github.com/GRA0007)
 - [Tim Tran](https://github.com/spacediscotqtt)
+
+It was then expanded on by more capstone groups
+
+<details>
+    <summary>Group 2</summary>
+    - [Conor Christensen](https://github.com/ConorChristensen-RMIT)
+    - [Jessani Linsangan](https://github.com/s3844703)
+    - [Lachlan Blennerhassett](https://github.com/Canni6)
+    - [Tomas Haddad](https://github.com/tomashaddad)
+    - [Oliver Hale](https://github.com/s3781403)
+</details>
+
+<details>
+    <summary>Group 3</summary>
+    - [Ope Abbas](https://github.com/OpeAbbas)
+    - [Sidhra Fernando-Plant](https://github.com/SidhraFernando-Plant)
+    - [Jake Leahy](https://github.com/ire4ever1190)
+    - [Aung Pyae Sone](https://github.com/eddie7788)
+    - [Lachlan Van Der Klift](https://github.com/LvandoApps)
+</details>
 
 ## Project Structure
 

--- a/README.md
+++ b/README.md
@@ -19,21 +19,23 @@ Automatarium is built by RMIT students with the original members being
 It was then expanded on by more capstone groups
 
 <details>
-    <summary>Group 2</summary>
-    - [Conor Christensen](https://github.com/ConorChristensen-RMIT)
-    - [Jessani Linsangan](https://github.com/s3844703)
-    - [Lachlan Blennerhassett](https://github.com/Canni6)
-    - [Tomas Haddad](https://github.com/tomashaddad)
-    - [Oliver Hale](https://github.com/s3781403)
+<summary>Group 2</summary>
+
+- [Conor Christensen](https://github.com/ConorChristensen-RMIT)
+- [Jessani Linsangan](https://github.com/s3844703)
+- [Lachlan Blennerhassett](https://github.com/Canni6)
+- [Tomas Haddad](https://github.com/tomashaddad)
+- [Oliver Hale](https://github.com/s3781403)
 </details>
 
 <details>
-    <summary>Group 3</summary>
-    - [Ope Abbas](https://github.com/OpeAbbas)
-    - [Sidhra Fernando-Plant](https://github.com/SidhraFernando-Plant)
-    - [Jake Leahy](https://github.com/ire4ever1190)
-    - [Aung Pyae Sone](https://github.com/eddie7788)
-    - [Lachlan Van Der Klift](https://github.com/LvandoApps)
+<summary>Group 3</summary>
+
+- [Ope Abbas](https://github.com/OpeAbbas)
+- [Sidhra Fernando-Plant](https://github.com/SidhraFernando-Plant)
+- [Jake Leahy](https://github.com/ire4ever1190)
+- [Aung Pyae Sone](https://github.com/eddie7788)
+- [Lachlan Van Der Klift](https://github.com/LvandoApps)
 </details>
 
 ## Project Structure

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ It was then expanded on by more capstone groups
 
 - [Ope Abbas](https://github.com/OpeAbbas)
 - [Sidhra Fernando-Plant](https://github.com/SidhraFernando-Plant)
+- [Lachlan Van Der Klift](https://github.com/LvandoApps)
 - [Jake Leahy](https://github.com/ire4ever1190)
 - [Aung Pyae Sone](https://github.com/eddie7788)
-- [Lachlan Van Der Klift](https://github.com/LvandoApps)
 </details>
 
 ## Project Structure


### PR DESCRIPTION
This adds our group along with last semesters group to the readme

I put the names in a drop down so (hopefully) as more groups use this repo and append to it, it won't take up the entire readme