### PR TITLE
Fix exporting projects with dot in the name

### DIFF
--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -69,12 +69,14 @@ const useActions = (registerHotkeys = false) => {
       handler: () => {
         // Pull project state
         const { project: { _id, userid, ...project } } = useProjectStore.getState()
+        console.log(project);
 
         // Create a download link and use it
         const a = document.createElement('a')
         const file = new Blob([JSON.stringify(project, null, 2)], { type: 'application/json' })
         a.href = URL.createObjectURL(file)
-        a.download = project.meta.name.replace(/[#%&{}\\<>*?/$!'":@+`|=]/g, '')
+        a.download = project.meta.name.replace(/[#%&{}\\<>*?/$!'":@+`|=]/g, '') + '.json'
+        console.log(a);
         a.click()
       }
     },

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -69,14 +69,13 @@ const useActions = (registerHotkeys = false) => {
       handler: () => {
         // Pull project state
         const { project: { _id, userid, ...project } } = useProjectStore.getState()
-        console.log(project);
 
         // Create a download link and use it
         const a = document.createElement('a')
         const file = new Blob([JSON.stringify(project, null, 2)], { type: 'application/json' })
         a.href = URL.createObjectURL(file)
+        // File extension explicitly added to allow for file names with dots
         a.download = project.meta.name.replace(/[#%&{}\\<>*?/$!'":@+`|=]/g, '') + '.json'
-        console.log(a);
         a.click()
       }
     },


### PR DESCRIPTION
Projects with a dot in the name will now be exported with the correct file extension. For example, the project Motionless.Sapling will be exported as Motionless.Sapling.json and can be successfully be imported. 

Projects without dots in the name will still be exported correctly, eg Motionless Sapling will be exported as 
Motionless Sapling.json.

The .json file extension is now explicitly added to the name of the export file in the code.