### PR TITLE
Separate contributing guide and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report a bug or issue with Automatarium
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - Before you create an issue please read the [contributing guide](https://github.com/automatarium/automatarium/blob/dev/CONTRIBUTING.md).
+        - Check to make sure someone hasn't already opened a similar [issue](https://github.com/github/docs/issues).
+
+  - type: textarea
+    attributes:
+      label: Description of the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: To reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: A clear and concise description of what you expected to happen.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Add any other context including screenshots and device information where applicable here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Automatarium wiki
+    url: https://github.com/automatarium/automatarium/wiki
+    about: Check the wiki if you're asking a question to make sure it hasn't already been answered.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an idea for Automatarium
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        - Before you create an issue please read the [contributing guide](https://github.com/automatarium/automatarium/blob/dev/CONTRIBUTING.md).
+        - Check to make sure someone hasn't already opened a similar [issue](https://github.com/github/docs/issues).
+
+  - type: textarea
+    attributes:
+      label: Proposed feature or solution
+      description: A clear and concise description of what you want to happen and why.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Alternatives
+      description: Give a clear and concise description of any alternative solutions or features you've considered.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Add any other context or screenshots about the feature request here.
+    validations:
+      required: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to Automatarium
+
+Automatarium is primarily a student-driven project developed at [RMIT University](https://www.rmit.edu.au/) in Australia, however we appreciate and encourage community contributions in the form of issues or pull requests.
+
+Most of the project architecture and structure is described in detail in the [contributor guide](https://github.com/automatarium/automatarium/wiki/Project-Architecture) section of the wiki. If you find any pages that are out of date or lacking information, please improve them.
+
+## Creating Issues
+
+If you find a bug or have a feature request, you can [create an issue](https://github.com/automatarium/automatarium/issues/new/choose) and describe in detail what is going wrong/what you think could be improved.
+
+## Project Structure
+
+Automatarium is a React project with a Node JS backend (that connects to a MongoDB database). We have two packages for automata simulation and jflap to automatarium file conversion.
+
+## Setup
+
+1. Clone this repository onto your local machine
+2. Run `yarn` to install dependencies (don't have yarn? run `npm i -g yarn`)
+3. Optionally, set up environment variables in a `.env` file in the backend to connect to a database
+4. Run `yarn dev` to start the dev server at [http://localhost:1234](http://localhost:1234)
+
+There are also other yarn commands, for example you can run `yarn dev:frontend` to start the frontend without the backend (useful to test functionality without connecting a database). See `package.json` for all available commands.
+
+## Development
+
+This project is set up using yarn workspaces. To install a new dependency, run `yarn workspace <folder> add <package>`, where `folder` is frontend, backend, @automatarium/simulation, or @automatarium/jflap-translator, and `package` is the package you wish to add.
+
+Before making PR, check your code with `yarn lint`
+
+## Deployment
+
+1. Ensure dependencies are installed by running `yarn`
+2. Run `yarn build` to build the packages, backend and frontend

--- a/README.md
+++ b/README.md
@@ -2,13 +2,19 @@
 
 > A place for automata
 
-Automatarium is a modern take on the useful [JFLAP](https://www.jflap.org/), but designed with a modern user interface and quality-of-life features that were lacking in JFLAP. Currently Automatarium supports finite automata, with room to add additional functionality such as push-down automata and Turing machines in the future.
+Automatarium is a modern take on the useful [JFLAP](https://www.jflap.org/), but designed with a modern user interface and quality-of-life features that JFLAP was lacking. Currently, Automatarium fully supports finite automata, with basic  functionality implemented for push-down automata and Turing machines.
+
+💡 For more details on _using_ Automatarium, check out the [user guide](https://github.com/automatarium/automatarium/wiki/Introduction) on the wiki.
 
 ![Screenshot of Automatarium editor](./screenshot.png)
 
+## Contributing
+
+For details on contributing to Automatarium, please read the [contributing guide](./CONTRIBUTING.md).
+
 ## Contributors
 
-Automatarium is built by RMIT students with the original members being
+Automatarium is built primarily by [RMIT University](https://www.rmit.edu.au/) students as a capstone project, created by the following students in 2022 (semester 1).
 
 - [Max Reid](https://github.com/Prydeton)
 - [Thomas Dib](https://github.com/tdib)
@@ -16,10 +22,11 @@ Automatarium is built by RMIT students with the original members being
 - [Benji Grant](https://github.com/GRA0007)
 - [Tim Tran](https://github.com/spacediscotqtt)
 
-It was then expanded on by more capstone groups
+It has since been picked up and worked on by more capstone groups.
 
 <details>
-<summary>Group 2</summary>
+<summary>Group 2 - 2022 Semester 2</summary>
+Implemented support for push-down automata and Turing machines, as well as improving simulation code.
 
 - [Conor Christensen](https://github.com/ConorChristensen-RMIT)
 - [Jessani Linsangan](https://github.com/s3844703)
@@ -29,7 +36,7 @@ It was then expanded on by more capstone groups
 </details>
 
 <details>
-<summary>Group 3</summary>
+<summary>Group 3 - 2023 Semester 1</summary>
 
 - [Ope Abbas](https://github.com/OpeAbbas)
 - [Sidhra Fernando-Plant](https://github.com/SidhraFernando-Plant)
@@ -38,29 +45,7 @@ It was then expanded on by more capstone groups
 - [Aung Pyae Sone](https://github.com/eddie7788)
 </details>
 
-## Project Structure
-
-Automatarium is a React project with a Node JS backend (that connects to a MongoDB database). We have two packages for automata simulation and jflap to automatarium file conversion.
-
-## Setup
-
-1. Clone this repository onto your local machine
-2. Run `yarn` to install dependencies (don't have yarn? run `npm i -g yarn`)
-3. Optionally, set up environment variables in a `.env` file in the backend to connect to a database
-4. Run `yarn dev` to start the dev server at [http://localhost:1234](http://localhost:1234)
-
-There are also other yarn commands, for example you can run `yarn dev:frontend` to start the frontend without the backend (useful to test functionality without connecting a database). See `package.json` for all available commands.
-
-## Development
-
-This project is set up using yarn workspaces. To install a new dependency, run `yarn workspace <folder> add <package>`, where `folder` is frontend, backend, @automatarium/simulation, or @automatarium/jflap-translator, and `package` is the package you wish to add.
-
-Before making PR, check your code with `yarn lint`
-
-## Deployment
-
-1. Ensure dependencies are installed by running `yarn`
-2. Run `yarn build` to build the packages, backend and frontend
+For a full list of contributors see: https://github.com/automatarium/automatarium/graphs/contributors
 
 ## License
 


### PR DESCRIPTION
Yo I thought I'd try and improve the public face of Automatarium by simplifying the README and moving contribution information to a CONTRIBUTING.md file. I've also added some issue templates, feel free to not use them internally, or change them up to suit your needs.

Happy to make any changes if requested :)