### PR TITLE
Disables running multitrace automatically

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.js
@@ -151,10 +151,6 @@ const TestingLab = () => {
     setTraceIdx(0)
   }, [lastChangeDate])
 
-  useEffect(() => {
-    rerunMultiTraceInput()
-  }, [])
-
   // Set the trace IDx to be passed through store to TMTapeLab component
   useEffect(() => {
     if (projectType === 'TM') { setProjectSimTraceIDx(traceIdx) }


### PR DESCRIPTION
Means that when loading an empty project, the user won't just get red in the multitest area. Also means there won't be red when they aren't even using the multirun tester