### PR TITLE
Add tests for `simulation` package

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
 
       - name: Install Yarn Dependencies

--- a/packages/simulation/package.json
+++ b/packages/simulation/package.json
@@ -15,6 +15,8 @@
     "lint:fix": "eslint . --ext .js,.ts --fix"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "@types/node": "^18.15.10",
     "@typescript-eslint/eslint-plugin": "^5.54.1",
     "@typescript-eslint/parser": "^5.54.1",
     "eslint": "^8.0.1",
@@ -28,7 +30,5 @@
     "ts-jest": "^29.0.5",
     "typescript": "^4.7.3"
   },
-  "dependencies": {
-    "@types/jest": "^29.5.0"
-  }
+  "dependencies": {}
 }

--- a/packages/simulation/src/PDASearch.ts
+++ b/packages/simulation/src/PDASearch.ts
@@ -36,8 +36,9 @@ export class PDAState extends State {
 
   key () {
     // It is important that the key values are seperated or else collisions could occur
-    // e.g. if the remaining is A and the stack is A, that would be the same as remaining AA with empty stack
-    return String(this.id + '_' + this.remaining + '_' + this.stack.join(''))
+    // e.g. if the remaining is A and the stack is A, that would be the same as remaining AA with empty stack.
+    // They are divided by the ID so that collisions won't occur if a dividing character appears
+    return String(this.remaining + this.id.toString() +  this.stack.join(''))
   }
 }
 

--- a/packages/simulation/src/PDASearch.ts
+++ b/packages/simulation/src/PDASearch.ts
@@ -35,7 +35,9 @@ export class PDAState extends State {
   }
 
   key () {
-    return String(this.id + this.remaining + this.stack.join(''))
+    // It is important that the key values are seperated or else collisions could occur
+    // e.g. if the remaining is A and the stack is A, that would be the same as remaining AA with empty stack
+    return String(this.id + '_' + this.remaining + '_' + this.stack.join(''))
   }
 }
 

--- a/packages/simulation/src/PDASearch.ts
+++ b/packages/simulation/src/PDASearch.ts
@@ -38,7 +38,7 @@ export class PDAState extends State {
     // It is important that the key values are seperated or else collisions could occur
     // e.g. if the remaining is A and the stack is A, that would be the same as remaining AA with empty stack.
     // They are divided by the ID so that collisions won't occur if a dividing character appears
-    return String(this.remaining + this.id.toString() +  this.stack.join(''))
+    return String(this.remaining + this.id.toString() + this.stack.join(''))
   }
 }
 

--- a/packages/simulation/src/TMSearch.ts
+++ b/packages/simulation/src/TMSearch.ts
@@ -13,7 +13,7 @@ export class TMState extends State {
 
   key () {
     const traceAdd = this._tape.trace.toString() ?? ''
-    return String(this.id + traceAdd)
+    return String(this.id + ',' + this._tape.pointer + ',' + traceAdd)
   }
 
   get tape () {
@@ -50,12 +50,12 @@ export class TMGraph extends Graph<TMState, TMTransition> {
 
       // If there is no next state
       if (
-        nextState === undefined || (!transition.read.includes(symbol)) || nextTape.pointer < 0
+        nextState === undefined || (!transition.read.includes(symbol) && symbol !== undefined) || nextTape.pointer < 0
       ) {
         continue
       }
-
-      if (transition.read === symbol) {
+      // Either the transition has same symbol or its a lambda transition
+      if (transition.read === symbol || (transition.read === '' && symbol === undefined)) {
         const graphState = new TMState(
           nextState.id,
           nextState.isFinal,

--- a/packages/simulation/src/TMSearch.ts
+++ b/packages/simulation/src/TMSearch.ts
@@ -45,17 +45,17 @@ export class TMGraph extends Graph<TMState, TMTransition> {
       const tapePointer = node.state.tape.pointer
       const tapeTrace = node.state.tape.trace
 
-      const symbol = tapeTrace[tapePointer]
+      // Undefined means its out of tape bounds, so we treat that has a lambda transition
+      const symbol = tapeTrace[tapePointer] ?? ''
       const nextTape = this.progressTape(node, transition)
 
       // If there is no next state
       if (
-        nextState === undefined || (!transition.read.includes(symbol) && symbol !== undefined) || nextTape.pointer < 0
+        nextState === undefined || (!transition.read.includes(symbol)) || nextTape.pointer < 0
       ) {
         continue
       }
-      // Either the transition has same symbol or its a lambda transition
-      if (transition.read === symbol || (transition.read === '' && symbol === undefined)) {
+      if (transition.read === symbol) {
         const graphState = new TMState(
           nextState.id,
           nextState.isFinal,

--- a/packages/simulation/src/graph.d.ts
+++ b/packages/simulation/src/graph.d.ts
@@ -31,6 +31,10 @@ export type PDAState = State & {
     stack: string[];
 };
 
+export type TMStateIn = State & {
+  tape?: Tape // tape is set during execution of simulateTM
+}
+
 /**
  * Defines
  */
@@ -85,7 +89,7 @@ export type PDAGraphIn = {
 // Will be used for importing from front end
 export type TMGraphIn = {
     initialState: StateID
-    states: TMState[]
+    states: TMStateIn[]
     transitions: TMTransition[]
 }
 

--- a/packages/simulation/src/graph.d.ts
+++ b/packages/simulation/src/graph.d.ts
@@ -7,13 +7,16 @@
  * TODO: Remove the need for `In` types and just the `Graph` type in frontend
  */
 
-import { TMState } from './TMSearch'
-
 export type ReadSymbol = string;
 export type StateID = number;
 export type TransitionID = number;
 export type PopSymbol = string;
 export type PushSymbol = string;
+
+export type Tape ={
+    pointer: number
+    trace: string[]
+}
 
 type State = {
     id: StateID;
@@ -97,11 +100,6 @@ export type ExecutionTrace = {
     read: string | null;
     to: StateID;
 };
-
-export type Tape ={
-    pointer: number
-    trace: string[]
-}
 
 export type ExecutionResult = {
     accepted: boolean;

--- a/packages/simulation/tests/graphs/a2b2a.json
+++ b/packages/simulation/tests/graphs/a2b2a.json
@@ -1,0 +1,65 @@
+{
+  "projectType": "TM",
+  "states": [
+    {
+      "isFinal": false,
+      "x": 420,
+      "y": 390,
+      "id": 0
+    },
+    {
+      "isFinal": true,
+      "x": 600,
+      "y": 390,
+      "id": 1
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "to": 0,
+      "id": 0,
+      "write": "B",
+      "direction": "R",
+      "read": "A"
+    },
+    {
+      "from": 0,
+      "to": 1,
+      "id": 1,
+      "write": "",
+      "direction": "L",
+      "read": ""
+    },
+    {
+      "from": 1,
+      "to": 1,
+      "id": 2,
+      "write": "A",
+      "direction": "L",
+      "read": "B"
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "AAAAA",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "a2b2a",
+    "dateCreated": 1679743784457,
+    "dateEdited": 1679743784457,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "TM",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "purple"
+  }
+}

--- a/packages/simulation/tests/graphs/a2b2a.json
+++ b/packages/simulation/tests/graphs/a2b2a.json
@@ -4,14 +4,26 @@
     {
       "isFinal": false,
       "x": 420,
-      "y": 390,
+      "y": 420,
       "id": 0
     },
     {
-      "isFinal": true,
-      "x": 600,
-      "y": 390,
+      "isFinal": false,
+      "x": 675,
+      "y": 420,
       "id": 1
+    },
+    {
+      "isFinal": false,
+      "x": 870,
+      "y": 420,
+      "id": 2
+    },
+    {
+      "isFinal": true,
+      "x": 1020,
+      "y": 420,
+      "id": 3
     }
   ],
   "transitions": [
@@ -38,12 +50,36 @@
       "write": "A",
       "direction": "L",
       "read": "B"
+    },
+    {
+      "from": 1,
+      "to": 2,
+      "id": 3,
+      "write": "A",
+      "direction": "L",
+      "read": "A"
+    },
+    {
+      "from": 1,
+      "to": 1,
+      "id": 4,
+      "write": "A",
+      "direction": "S",
+      "read": "B"
+    },
+    {
+      "from": 2,
+      "to": 3,
+      "id": 5,
+      "write": "A",
+      "direction": "S",
+      "read": "B"
     }
   ],
   "comments": [],
   "simResult": [],
   "tests": {
-    "single": "AAAAA",
+    "single": "",
     "batch": [
       ""
     ]
@@ -51,8 +87,8 @@
   "initialState": 0,
   "meta": {
     "name": "a2b2a",
-    "dateCreated": 1679743784457,
-    "dateEdited": 1679743784457,
+    "dateCreated": 1679870186759,
+    "dateEdited": 1679870251655,
     "version": "1.0.0",
     "automatariumVersion": "1.0.0"
   },

--- a/packages/simulation/tests/graphs/bepsi.json
+++ b/packages/simulation/tests/graphs/bepsi.json
@@ -1,0 +1,71 @@
+{
+  "projectType": "TM",
+  "states": [
+    {
+      "isFinal": false,
+      "x": 315,
+      "y": 285,
+      "id": 0
+    },
+    {
+      "isFinal": false,
+      "x": 495,
+      "y": 270,
+      "id": 1
+    },
+    {
+      "isFinal": true,
+      "x": 720,
+      "y": 240,
+      "id": 2
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "to": 1,
+      "id": 1,
+      "write": "B",
+      "direction": "R",
+      "read": "B"
+    },
+    {
+      "from": 1,
+      "to": 2,
+      "id": 2,
+      "write": "A",
+      "direction": "R",
+      "read": "B"
+    },
+    {
+      "from": 1,
+      "to": 1,
+      "id": 3,
+      "write": "C",
+      "direction": "R",
+      "read": "C"
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "BCB",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Nervous Gravel",
+    "dateCreated": 1679305311849,
+    "dateEdited": 1679305311849,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "TM",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "purple"
+  }
+}

--- a/packages/simulation/tests/graphs/evenAs.json
+++ b/packages/simulation/tests/graphs/evenAs.json
@@ -1,0 +1,65 @@
+{
+  "projectType": "PDA",
+  "states": [
+    {
+      "isFinal": false,
+      "x": 420,
+      "y": 450,
+      "id": 0
+    },
+    {
+      "isFinal": true,
+      "x": 585,
+      "y": 450,
+      "id": 1
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "to": 0,
+      "id": 0,
+      "pop": "",
+      "push": "A",
+      "read": "A"
+    },
+    {
+      "from": 1,
+      "to": 1,
+      "id": 1,
+      "pop": "A",
+      "push": "",
+      "read": "A"
+    },
+    {
+      "from": 0,
+      "to": 1,
+      "id": 2,
+      "pop": "",
+      "push": "",
+      "read": ""
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "AAAA",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "evenAs",
+    "dateCreated": 1679742139962,
+    "dateEdited": 1679742139962,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "PDA",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "red"
+  }
+}

--- a/packages/simulation/tests/graphs/shuffleLeft.json
+++ b/packages/simulation/tests/graphs/shuffleLeft.json
@@ -1,0 +1,57 @@
+{
+  "projectType": "TM",
+  "states": [
+    {
+      "isFinal": false,
+      "x": 420,
+      "y": 420,
+      "id": 0
+    },
+    {
+      "isFinal": true,
+      "x": 585,
+      "y": 420,
+      "id": 1
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "to": 0,
+      "id": 0,
+      "write": "A",
+      "direction": "R",
+      "read": "A"
+    },
+    {
+      "from": 0,
+      "to": 1,
+      "id": 1,
+      "write": "Z",
+      "direction": "S",
+      "read": "Z"
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "shuffleLeft",
+    "dateCreated": 1679870186759,
+    "dateEdited": 1679870251655,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "TM",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "purple"
+  }
+}

--- a/packages/simulation/tests/simulatePDA.test.ts
+++ b/packages/simulation/tests/simulatePDA.test.ts
@@ -1,7 +1,7 @@
 import evenAs from './graphs/evenAs.json'
 import { simulatePDA } from '../src'
 
-describe('Automata that accept even number of A', () => {
+describe('Automata that accepts an even number of A', () => {
   test('Accepts lambda', () => {
     const result = simulatePDA(evenAs, '')
     expect(result.accepted).toBeTrue()
@@ -9,6 +9,12 @@ describe('Automata that accept even number of A', () => {
 
   test('Accepts AA', () => {
     const result = simulatePDA(evenAs, 'AA')
+    expect(result.trace.map(it => it.currentStack)).toEqual([
+      [], // Initial
+      ['A'], // First A read
+      ['A'], // Lambda transition
+      [] // Second A read
+    ])
     expect(result.accepted).toBeTrue()
   })
 

--- a/packages/simulation/tests/simulatePDA.test.ts
+++ b/packages/simulation/tests/simulatePDA.test.ts
@@ -1,0 +1,19 @@
+import evenAs from './graphs/evenAs.json'
+import { simulatePDA } from '../src'
+
+describe('Automata that accept even number of A', () => {
+  test('Accepts lambda', () => {
+    const result = simulatePDA(evenAs, '')
+    expect(result.accepted).toBeTrue()
+  })
+
+  test('Accepts AA', () => {
+    const result = simulatePDA(evenAs, 'AA')
+    expect(result.accepted).toBeTrue()
+  })
+
+  test('Rejects AAA', () => {
+    const result = simulatePDA(evenAs, 'AAA')
+    expect(result.accepted).toBeFalse()
+  })
+})

--- a/packages/simulation/tests/simulateTM.test.ts
+++ b/packages/simulation/tests/simulateTM.test.ts
@@ -5,10 +5,10 @@ import { TMExecutionResult, TMGraphIn } from '../src/graph'
 function simulate (graph: TMGraphIn, input: string): TMExecutionResult {
   return simulateTM(graph, { pointer: 0, trace: input ? input.split('') : [''] })
 }
+const result = simulate(a2b2a, 'AA')
 
 describe('Turing machine that converts A to B then resets tape', () => {
   test('Accepts AA', () => {
-    const result = simulate(a2b2a, 'AA')
     expect(result.halted).toBeTrue()
   })
 })

--- a/packages/simulation/tests/simulateTM.test.ts
+++ b/packages/simulation/tests/simulateTM.test.ts
@@ -1,0 +1,14 @@
+import a2b2a from './graphs/a2b2a.json'
+import { simulateTM } from '../src/simulateTM'
+import { TMExecutionResult, TMGraphIn } from '../src/graph'
+
+function simulate (graph: TMGraphIn, input: string): TMExecutionResult {
+  return simulateTM(graph, { pointer: 0, trace: input ? input.split('') : [''] })
+}
+
+describe('Turing machine that converts A to B then resets tape', () => {
+  test('Accepts AA', () => {
+    const result = simulate(a2b2a, 'AA')
+    expect(result.halted).toBeTrue()
+  })
+})

--- a/packages/simulation/tests/simulateTM.test.ts
+++ b/packages/simulation/tests/simulateTM.test.ts
@@ -1,5 +1,6 @@
 import a2b2a from './graphs/a2b2a.json'
 import shuffleLeft from './graphs/shuffleLeft.json'
+import bepsi from './graphs/bepsi.json'
 import { simulateTM } from '../src/simulateTM'
 import { TMExecutionResult, TMGraphIn } from '../src/graph'
 import { describe } from 'node:test'
@@ -22,10 +23,28 @@ describe('Machine that moves left', () => {
   })
 })
 
-describe('Turing machine that converts A to B then resets tape', () => {
+describe('Machine that converts A to B then resets tape', () => {
   test('Accepts AA', () => {
     const result = simulate(a2b2a, 'AA')
     expect(result.tape).toMatchObject({ pointer: 0, trace: ['A', 'A', ''] })
+    expect(result.halted).toBeTrue()
+  })
+})
+
+describe('Machine that must have Bs either side and can have Cs in the middle', () => {
+  test('Accepts BB', () => {
+    const result = simulate(bepsi, 'BB')
+    expect(result.halted).toBeTrue()
+  })
+
+  test('Accepts BCB', () => {
+    const result = simulate(bepsi, 'BB')
+    expect(result.halted).toBeTrue()
+  })
+
+  test('Tracing is correct for BCB', () => {
+    const result = simulate(bepsi, 'BCB')
+    expect(result.tape).toMatchObject({ pointer: 3, trace: ['B', 'C', 'A'] })
     expect(result.halted).toBeTrue()
   })
 })

--- a/packages/simulation/tests/simulateTM.test.ts
+++ b/packages/simulation/tests/simulateTM.test.ts
@@ -45,6 +45,12 @@ describe('Machine that must have Bs either side and can have Cs in the middle', 
   test('Tracing is correct for BCB', () => {
     const result = simulate(bepsi, 'BCB')
     expect(result.tape).toMatchObject({ pointer: 3, trace: ['B', 'C', 'A'] })
+    expect(result.trace).toMatchObject([
+      { to: 0, tape: { pointer: 0, trace: ['B', 'C', 'B'] } },
+      { to: 1, tape: { pointer: 1, trace: ['B', 'C', 'B'] } },
+      { to: 1, tape: { pointer: 2, trace: ['B', 'C', 'B'] } },
+      { to: 2, tape: { pointer: 3, trace: ['B', 'C', 'A'] } }
+    ])
     expect(result.halted).toBeTrue()
   })
 })

--- a/packages/simulation/tests/simulateTM.test.ts
+++ b/packages/simulation/tests/simulateTM.test.ts
@@ -1,6 +1,8 @@
 import a2b2a from './graphs/a2b2a.json'
+import shuffleLeft from './graphs/shuffleLeft.json'
 import { simulateTM } from '../src/simulateTM'
 import { TMExecutionResult, TMGraphIn } from '../src/graph'
+import { describe } from 'node:test'
 
 // Shim to allow for structuredClone alternative (See https://github.com/jsdom/jsdom/issues/3363)
 // This should work for our cases
@@ -12,10 +14,17 @@ function simulate (graph: TMGraphIn, input: string): TMExecutionResult {
   return simulateTM(graph, { pointer: 0, trace: input ? input.split('') : [''] })
 }
 
-const result = simulate(a2b2a, 'AA')
+describe('Machine that moves left', () => {
+  test('Machine halts', () => {
+    const result = simulate(shuffleLeft, 'AAAZ')
+    expect(result.tape).toMatchObject({ pointer: 3, trace: ['A', 'A', 'A', 'Z'] })
+    expect(result.halted).toBeTrue()
+  })
+})
 
 describe('Turing machine that converts A to B then resets tape', () => {
   test('Accepts AA', () => {
+    const result = simulate(a2b2a, 'AA')
     expect(result.tape).toMatchObject({ pointer: 0, trace: ['A', 'A', ''] })
     expect(result.halted).toBeTrue()
   })

--- a/packages/simulation/tests/simulateTM.test.ts
+++ b/packages/simulation/tests/simulateTM.test.ts
@@ -2,13 +2,21 @@ import a2b2a from './graphs/a2b2a.json'
 import { simulateTM } from '../src/simulateTM'
 import { TMExecutionResult, TMGraphIn } from '../src/graph'
 
+// Shim to allow for structuredClone alternative (See https://github.com/jsdom/jsdom/issues/3363)
+// This should work for our cases
+global.structuredClone = jest.fn(val => {
+  return JSON.parse(JSON.stringify(val))
+})
+
 function simulate (graph: TMGraphIn, input: string): TMExecutionResult {
   return simulateTM(graph, { pointer: 0, trace: input ? input.split('') : [''] })
 }
+
 const result = simulate(a2b2a, 'AA')
 
 describe('Turing machine that converts A to B then resets tape', () => {
   test('Accepts AA', () => {
+    expect(result.tape).toMatchObject({ pointer: 0, trace: ['A', 'A', ''] })
     expect(result.halted).toBeTrue()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3848,6 +3848,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
 
+"@types/node@^18.15.10":
+  version "18.15.10"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.10.tgz#4ee2171c3306a185d1208dad5f44dae3dee4cfe3"
+  integrity sha512-9avDaQJczATcXgfmMAW3MIWArOO7A+m90vuCFLr8AotWf8igO/mRoYukrk2cqZVtv38tHs33retzHEilM7FpeQ==
+
 "@types/parse-json@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"


### PR DESCRIPTION
Closes #288 

This adds unit tests for PDA's and TM's. These tests found 3 small bugs that I fixed in this PR to get them passing

- PDA state key could have collisions if stack and remaining contained same letters
- TM state key could have collisions if the tape wasn't modified and stayed in the same state (but changed position)
- TM didn't accept going paste the tape as being a lambda character