### PR TITLE
PDA and TM comment modals fixed

### DIFF
--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -278,8 +278,7 @@ const InputDialogs = () => {
       )}
     </Dropdown>
     )
-  }
- else {
+  } else {
     const isPDA = projectType === 'PDA'
     return (
       <Dropdown

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -380,8 +380,7 @@ const InputDialogs = () => {
       </>
           )}
       </Dropdown>
-    )
-  }
+    )}
   // Else we assume the project type is a FSA, if we're adding more automaton then we will have to make more if statements, one for each automaton to define the logic and formatting of transitions and comments.
   else {
     return (

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -197,6 +197,8 @@ const InputDialogs = () => {
   const isPDA = projectType === 'PDA'
   // If the project type if a TM, then do the following
   if (isTM) {
+    // Determine whether dialog type is TMtransition, comment, or state, and act accordingly.
+    // If it is none of these just return null.
     if (dialog.type === 'TMtransition') {
       return (
         <Dropdown
@@ -332,143 +334,254 @@ const InputDialogs = () => {
     else {
       return null;
     }
+    // Else if the project type is a PDA, do the following
   } else if (isPDA) {
-    return (
-      <Dropdown
-        visible={dialog.visible}
-        onClose={() => {
-          hideDialog()
-          // Delete transitions if not new
-          if (dialog.type === 'transition' && dialog.previousValue === undefined) {
-            removeTransitions([dialog.id])
-          }
-        }}
-        style={{
-          top: `${dialog.y}px`,
-          left: `${dialog.x}px`
-        }}
-      >
-        {(
-      <>
-        <InputWrapper>
-          {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }} />}
-          <Input
-            ref={inputRef}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyUp={(e) => e.key === 'Enter' && save()}
-            placeholder={{
-              transition: 'λ\t(read)',
-              comment: 'Comment text...',
-              stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
-              stateLabel: 'State label...'
-            }[dialog.type]}
-            style={{
-              width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-              margin: '0 .4em',
-              paddingRight: '2.5em'
-            }}
-            // Again, this distinguishes the first transition input box from the first comment input box. If this check is removed, there will be a submit button in the first input box
-            // for both transition and comment (looks better being at the bottom)
-          />
-          {dialog.type !== 'transition'
-            ? (
-              <SubmitButton onClick={save}>
-                <CornerDownLeft size="18px" />
-              </SubmitButton>
-              )
-            : null}
-        </InputWrapper>
-      </>
-    )}
-          {dialog.type === 'transition' && (
-      <>
-        <Input
-          // Define rest of the transition input boxes
-          ref={inputPopRef}
-          value={valuePop}
-          onChange={e => setValuePop(e.target.value)}
-          onKeyUp={e => e.key === 'Enter' && save()}
-          placeholder={{
-            transition: 'λ\t(pop)'
-          }[dialog.type]}
-          style={{
-            width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-            margin: '0 .4em',
-            paddingRight: '2.5em'
+    // Determine whether dialog type is transition, comment, or state, and act accordingly.
+    // If it is none of these just return null.
+    if (dialog.type === 'transition') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+            if (dialog.previousValue === undefined) {
+              removeTransitions([dialog.id])
+            }
           }}
-        />
-        <InputWrapper>
-        <Input
-          ref={inputPushRef}
-          value={valuePush}
-          onChange={e => setValuePush(e.target.value)}
-          onKeyUp={e => e.key === 'Enter' && save()}
-          placeholder={{
-            transition: 'λ\t(push)'
-          }[dialog.type]}
           style={{
-            width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-            margin: '0 .4em',
-            paddingRight: '2.5em'
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
           }}
-          // The submit button in line with the final transition input box
-        />
-        <SubmitButton onClick={save}>
-          <CornerDownLeft size="18px" />
-        </SubmitButton>
-        </InputWrapper>
-      </>
-          )}
-      </Dropdown>
-    )
+        >
+          <InputWrapper>
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'λ\t(read)'}
+              style={{
+                width: 'calc(12ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+          </InputWrapper>
+          <InputWrapper>
+            <Input
+              ref={inputPopRef}
+              value={valuePop}
+              onChange={e => setValuePop(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'λ\t(pop)'}
+              style={{
+                width: 'calc(12ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+          </InputWrapper>
+          <InputWrapper>
+            <Input
+              ref={inputPushRef}
+              value={valuePush}
+              onChange={e => setValuePush(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'λ\t(push)'}
+              style={{
+                width: 'calc(12ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else if (dialog.type === 'comment') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <MessageSquare style={{ marginInline: '1em .6em' }} />
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'Comment text...'}
+              style={{
+                width: 'calc(20ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else if (dialog.type === 'state') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <Type style={{ marginInline: '1em .6em' }} />
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={{
+                stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
+                stateLabel: 'State label...'
+              }[dialog.placeholderType]}
+              style={{
+                width: 'calc(20ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else {
+      return null;
+    }
     // Else we assume the project type is a FSA, if we're adding more automaton then we will have to make more if statements, one for each automaton to define the logic and formatting of transitions and comments.
   } else {
-    return (
-      <Dropdown
-        visible={dialog.visible}
-        onClose={() => {
-          hideDialog()
-          // Delete transitions if not new
-          if (dialog.type === 'transition' && dialog.previousValue === undefined) {
-            removeTransitions([dialog.id])
-          }
-        }}
-        style={{
-          top: `${dialog.y}px`,
-          left: `${dialog.x}px`
-        }}
-      >
-        {(
-      <>
-        <InputWrapper>
-          {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }} />}
-          <Input
-            ref={inputRef}
-            value={value}
-            onChange={(e) => setValue(e.target.value)}
-            onKeyUp={(e) => e.key === 'Enter' && save()}
-            placeholder={{
-              transition: 'λ',
-              comment: 'Comment text...',
-              stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
-              stateLabel: 'State label...'
-            }[dialog.type]}
-            style={{
-              width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-              margin: '0 .4em',
-              paddingRight: '2.5em'
-            }}
-            // No need to distinguish between comment and transition here, as there is only 1 of each.
-          />
-              <SubmitButton onClick={save}>
-                <CornerDownLeft size="18px" />
-              </SubmitButton>
-        </InputWrapper>
-      </>
-    )}
-    </Dropdown>
-    )
+    if (dialog.type === 'transition') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+            if (dialog.previousValue === undefined) {
+              removeTransitions([dialog.id])
+            }
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'λ'}
+              style={{
+                width: 'calc(12ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else if (dialog.type === 'comment') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <MessageSquare style={{ marginInline: '1em .6em' }} />
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'Comment text...'}
+              style={{
+                width: 'calc(20ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else if (dialog.type === 'state') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <Type style={{ marginInline: '1em .6em' }} />
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={{
+                stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
+                stateLabel: 'State label...'
+              }[dialog.placeholderType]}
+              style={{
+                width: 'calc(20ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else {
+      return null;
+    }
   }
 }
 

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -194,6 +194,8 @@ const InputDialogs = () => {
   }
 
   const isTM = projectType === 'TM'
+  const isPDA = projectType === 'PDA'
+  // If the project type if a TM, then do the following
   if (isTM) {
     return (
     <Dropdown
@@ -215,6 +217,7 @@ const InputDialogs = () => {
       <InputWrapper>
           {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }} />}
           <Input
+            // The above puts a message icon in any comment box
             ref={inputRef}
             value={dialog.type === 'comment' ? value : read}
             onChange={(e) => dialog.type === 'comment' ? setValue(e.target.value) : handleReadIn(e)}
@@ -225,13 +228,19 @@ const InputDialogs = () => {
               stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
               stateLabel: 'State label...'
             }[dialog.type]}
+            // Common styling. This can be changed later if needed, however it looks good like this. Ensure all other templates and boxes
+            // follow this formatting for consistency, or if it is changed, ensure everything is changed (I will be watching)
             style={{
               width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
               margin: '0 .4em',
               paddingRight: '2.5em'
             }}
+            // We check if the dialog type is not a TMtransition, if it is then we don't include a 2nd submit button, if it isnt
+            // then it must be a comment, so we do include the submit button. This is because the first input box and the comment box
+            // must be defined at the same time (there is obviously a way around this, however the logic is understandable to the point where refactoring
+            // massively to change this isn't really worth it). Similar logic applies to the submit buttons for PDA and FSA.
           />
-          {!isTM || dialog.type !== 'TMtransition'
+          {dialog.type !== 'TMtransition'
             ? (
               <SubmitButton onClick={save}>
                 <CornerDownLeft size="18px" />
@@ -245,6 +254,7 @@ const InputDialogs = () => {
   <>
     <InputWrapper>
       <Input
+        // Now we define the remainder of the transition inputs
         ref={inputWriteRef}
         value={write}
         onChange={handleWriteIn}
@@ -269,6 +279,8 @@ const InputDialogs = () => {
           margin: '0 .4em',
           paddingRight: '2.5em'
         }}
+        // This will be the submit button defined at the bottom of the transitions (in line with the final input).
+        // If this is not the case, call halil.
       />
       <SubmitButton onClick={save}>
         <CornerDownLeft size="18px" />
@@ -278,8 +290,8 @@ const InputDialogs = () => {
       )}
     </Dropdown>
     )
-  } else {
-    const isPDA = projectType === 'PDA'
+    // Else if the project type is a PDA, do the following
+  } else if (isPDA) {
     return (
       <Dropdown
         visible={dialog.visible}
@@ -305,7 +317,7 @@ const InputDialogs = () => {
             onChange={(e) => setValue(e.target.value)}
             onKeyUp={(e) => e.key === 'Enter' && save()}
             placeholder={{
-              transition: (projectType === 'PDA') ? 'λ\t(read)' : 'λ',
+              transition: 'λ\t(read)',
               comment: 'Comment text...',
               stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
               stateLabel: 'State label...'
@@ -315,8 +327,10 @@ const InputDialogs = () => {
               margin: '0 .4em',
               paddingRight: '2.5em'
             }}
+            // Again, this distinguishes the first transition input box from the first comment input box. If this check is removed, there will be a submit button in the first input box
+            // for both transition and comment (looks better being at the bottom)
           />
-          {!isPDA || dialog.type !== 'transition'
+          {dialog.type !== 'transition'
             ? (
               <SubmitButton onClick={save}>
                 <CornerDownLeft size="18px" />
@@ -326,9 +340,10 @@ const InputDialogs = () => {
         </InputWrapper>
       </>
     )}
-          {dialog.type === 'transition' && isPDA && (
+          {dialog.type === 'transition' && (
       <>
         <Input
+          // Define rest of the transition input boxes
           ref={inputPopRef}
           value={valuePop}
           onChange={e => setValuePop(e.target.value)}
@@ -356,6 +371,7 @@ const InputDialogs = () => {
             margin: '0 .4em',
             paddingRight: '2.5em'
           }}
+          // The submit button in line with the final transition input box
         />
         <SubmitButton onClick={save}>
           <CornerDownLeft size="18px" />
@@ -364,6 +380,54 @@ const InputDialogs = () => {
       </>
           )}
       </Dropdown>
+    )
+  }
+  // Else we assume the project type is a FSA, if we're adding more automaton then we will have to make more if statements, one for each automaton to define the logic and formatting of transitions and comments.
+  else {
+    return (
+      <Dropdown
+        visible={dialog.visible}
+        onClose={() => {
+          hideDialog()
+          // Delete transitions if not new
+          if (dialog.type === 'transition' && dialog.previousValue === undefined) {
+            removeTransitions([dialog.id])
+          }
+        }}
+        style={{
+          top: `${dialog.y}px`,
+          left: `${dialog.x}px`
+        }}
+      >
+        {(
+      <>
+        <InputWrapper>
+          {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }} />}
+          <Input
+            ref={inputRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyUp={(e) => e.key === 'Enter' && save()}
+            placeholder={{
+              transition: 'λ',
+              comment: 'Comment text...',
+              stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
+              stateLabel: 'State label...'
+            }[dialog.type]}
+            style={{
+              width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
+              margin: '0 .4em',
+              paddingRight: '2.5em'
+            }}
+            // No need to distinguish between comment and transition here, as there is only 1 of each.
+          />
+              <SubmitButton onClick={save}>
+                <CornerDownLeft size="18px" />
+              </SubmitButton>
+        </InputWrapper>
+      </>
+    )}
+    </Dropdown>
     )
   }
 }

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -261,8 +261,7 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else if (dialog.type === 'comment') {
+    } else if (dialog.type === 'comment') {
       return (
         <Dropdown
           visible={dialog.visible}
@@ -294,8 +293,7 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else if (dialog.type === 'state') {
+    } else if (dialog.type === 'state') {
       return (
         <Dropdown
           visible={dialog.visible}
@@ -308,7 +306,6 @@ const InputDialogs = () => {
           }}
         >
           <InputWrapper>
-            <Type style={{ marginInline: '1em .6em' }} />
             <Input
               ref={inputRef}
               value={value}
@@ -330,9 +327,8 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else {
-      return null;
+    } else {
+      return null
     }
     // Else if the project type is a PDA, do the following
   } else if (isPDA) {
@@ -400,8 +396,7 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else if (dialog.type === 'comment') {
+    } else if (dialog.type === 'comment') {
       return (
         <Dropdown
           visible={dialog.visible}
@@ -433,8 +428,7 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else if (dialog.type === 'state') {
+    } else if (dialog.type === 'state') {
       return (
         <Dropdown
           visible={dialog.visible}
@@ -447,7 +441,6 @@ const InputDialogs = () => {
           }}
         >
           <InputWrapper>
-            <Type style={{ marginInline: '1em .6em' }} />
             <Input
               ref={inputRef}
               value={value}
@@ -469,9 +462,8 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else {
-      return null;
+    } else {
+      return null
     }
     // Else we assume the project type is a FSA, if we're adding more automaton then we will have to make more if statements, one for each automaton to define the logic and formatting of transitions and comments.
   } else {
@@ -509,8 +501,7 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else if (dialog.type === 'comment') {
+    } else if (dialog.type === 'comment') {
       return (
         <Dropdown
           visible={dialog.visible}
@@ -542,8 +533,7 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else if (dialog.type === 'state') {
+    } else if (dialog.type === 'state') {
       return (
         <Dropdown
           visible={dialog.visible}
@@ -556,7 +546,6 @@ const InputDialogs = () => {
           }}
         >
           <InputWrapper>
-            <Type style={{ marginInline: '1em .6em' }} />
             <Input
               ref={inputRef}
               value={value}
@@ -578,9 +567,8 @@ const InputDialogs = () => {
           </InputWrapper>
         </Dropdown>
       )
-    }
-    else {
-      return null;
+    } else {
+      return null
     }
   }
 }

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -257,88 +257,91 @@ const InputDialogs = () => {
     </Dropdown>
     )
   } else {
+    const isPDA = projectType === 'PDA'
     return (
-        <Dropdown
-            visible={dialog.visible}
-            onClose={() => {
-              hideDialog()
-              // Delete transitions if not new
-              if (dialog.type === 'transition' && dialog.previousValue === undefined) {
-                removeTransitions([dialog.id])
-              }
-            }}
+      <Dropdown
+        visible={dialog.visible}
+        onClose={() => {
+          hideDialog()
+          // Delete transitions if not new
+          if (dialog.type === 'transition' && dialog.previousValue === undefined) {
+            removeTransitions([dialog.id])
+          }
+        }}
+        style={{
+          top: `${dialog.y}px`,
+          left: `${dialog.x}px`
+        }}
+      >
+        {(
+      <>
+        <InputWrapper>
+          {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }} />}
+          <Input
+            ref={inputRef}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onKeyUp={(e) => e.key === 'Enter' && save()}
+            placeholder={{
+              transition: (projectType === 'PDA') ? 'λ\t(read)' : 'λ',
+              comment: 'Comment text...',
+              stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
+              stateLabel: 'State label...'
+            }[dialog.type]}
             style={{
-              top: `${dialog.y}px`,
-              left: `${dialog.x}px`
+              width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
+              margin: '0 .4em',
+              paddingRight: '2.5em'
             }}
-        >
-          <InputWrapper>
-            {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }}/>}
-            <Input
-                ref={inputRef}
-                value={value}
-                onChange={e => setValue(e.target.value)}
-                onKeyUp={e => e.key === 'Enter' && save()}
-                placeholder={{
-                  transition: (projectType === 'PDA') ? 'λ\t(read)' : 'λ',
-                  comment: 'Comment text...',
-                  stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
-                  stateLabel: 'State label...'
-                }[dialog.type]}
-                style={{
-                  width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-                  margin: '0 .4em',
-                  paddingRight: '2.5em'
-                }}
-            />
-            {!projectType === 'PDA' &&
-            <SubmitButton onClick={save}>
-              <CornerDownLeft size="18px"/>
-            </SubmitButton>}
-          </InputWrapper>
-          { /* Additional input #1 - PDA pop value */}
-          {projectType === 'PDA' &&
-          <InputWrapper>
-            <Input
-                ref={inputPopRef}
-                value={valuePop}
-                onChange={e => setValuePop(e.target.value)}
-                onKeyUp={e => e.key === 'Enter' && save()}
-                placeholder={{
-                  transition: 'λ\t(pop)'
-                }[dialog.type]}
-                style={{
-                  width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-                  margin: '0 .4em',
-                  paddingRight: '2.5em'
-                }}
-            />
-          </InputWrapper>}
-          { /* Additional input #2 - PDA push value */}
-          {projectType === 'PDA' &&
-          <InputWrapper>
-            <Input
-                ref={inputPushRef}
-                value={valuePush}
-                onChange={e => setValuePush(e.target.value)}
-                onKeyUp={e => e.key === 'Enter' && save()}
-                placeholder={{
-                  transition: 'λ\t(push)'
-                }[dialog.type]}
-                style={{
-                  width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-                  margin: '0 .4em',
-                  paddingRight: '2.5em'
-                }}
-            />
-            {/* {console.log("valueRead is: ", value)}
-          {console.log("valuePop is: ", valuePop)}
-          {console.log("valuePush is: ", valuePush)} */}
-            <SubmitButton onClick={save}>
-              <CornerDownLeft size="18px"/>
-            </SubmitButton>
-          </InputWrapper>}
-        </Dropdown>
+          />
+          {!isPDA || dialog.type !== 'transition'
+            ? (
+              <SubmitButton onClick={save}>
+                <CornerDownLeft size="18px" />
+              </SubmitButton>
+              )
+            : null}
+        </InputWrapper>
+      </>
+    )}
+          {dialog.type === 'transition' && isPDA && (
+      <>
+        <Input
+          ref={inputPopRef}
+          value={valuePop}
+          onChange={e => setValuePop(e.target.value)}
+          onKeyUp={e => e.key === 'Enter' && save()}
+          placeholder={{
+            transition: 'λ\t(pop)'
+          }[dialog.type]}
+          style={{
+            width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
+            margin: '0 .4em',
+            paddingRight: '2.5em'
+          }}
+        />
+        <InputWrapper>
+        <Input
+          ref={inputPushRef}
+          value={valuePush}
+          onChange={e => setValuePush(e.target.value)}
+          onKeyUp={e => e.key === 'Enter' && save()}
+          placeholder={{
+            transition: 'λ\t(push)'
+          }[dialog.type]}
+          style={{
+            width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
+            margin: '0 .4em',
+            paddingRight: '2.5em'
+          }}
+        />
+        <SubmitButton onClick={save}>
+          <CornerDownLeft size="18px" />
+        </SubmitButton>
+        </InputWrapper>
+      </>
+          )}
+      </Dropdown>
     )
   }
 }

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -197,100 +197,141 @@ const InputDialogs = () => {
   const isPDA = projectType === 'PDA'
   // If the project type if a TM, then do the following
   if (isTM) {
-    return (
-    <Dropdown
-      visible={dialog.visible}
-      onClose={() => {
-        hideDialog()
-        // Delete transitions if not new
-        if (dialog.type === 'TMtransition' && dialog.previousValue === undefined) {
-          removeTransitions([dialog.id])
-        }
-      }}
-      style={{
-        top: `${dialog.y}px`,
-        left: `${dialog.x}px`
-      }}
-    >
-        {(
-      <>
-      <InputWrapper>
-          {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }} />}
-          <Input
-            // The above puts a message icon in any comment box
-            ref={inputRef}
-            value={dialog.type === 'comment' ? value : read}
-            onChange={(e) => dialog.type === 'comment' ? setValue(e.target.value) : handleReadIn(e)}
-            onKeyUp={(e) => e.key === 'Enter' && save()}
-            placeholder={{
-              TMtransition: 'λ\t(read)',
-              comment: 'Comment text...',
-              stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
-              stateLabel: 'State label...'
-            }[dialog.type]}
-            // Common styling. This can be changed later if needed, however it looks good like this. Ensure all other templates and boxes
-            // follow this formatting for consistency, or if it is changed, ensure everything is changed (I will be watching)
-            style={{
-              width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-              margin: '0 .4em',
-              paddingRight: '2.5em'
-            }}
-            // We check if the dialog type is not a TMtransition, if it is then we don't include a 2nd submit button, if it isnt
-            // then it must be a comment, so we do include the submit button. This is because the first input box and the comment box
-            // must be defined at the same time (there is obviously a way around this, however the logic is understandable to the point where refactoring
-            // massively to change this isn't really worth it). Similar logic applies to the submit buttons for PDA and FSA.
-          />
-          {dialog.type !== 'TMtransition'
-            ? (
-              <SubmitButton onClick={save}>
-                <CornerDownLeft size="18px" />
-              </SubmitButton>
-              )
-            : null}
-        </InputWrapper>
-        </>
-        )}
-      {dialog.type === 'TMtransition' && (
-  <>
-    <InputWrapper>
-      <Input
-        // Now we define the remainder of the transition inputs
-        ref={inputWriteRef}
-        value={write}
-        onChange={handleWriteIn}
-        onKeyUp={e => e.key === 'Enter' && save()}
-        placeholder={'λ\t(write)'}
-        style={{
-          width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-          margin: '0 .4em',
-          paddingRight: '2.5em'
-        }}
-      />
-    </InputWrapper>
-    <InputWrapper>
-      <Input
-        ref={inputDirectionRef}
-        value={direction}
-        onChange={handleDirectionIn}
-        onKeyUp={e => e.key === 'Enter' && save()}
-        placeholder={'↔\t(direction)'}
-        style={{
-          width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-          margin: '0 .4em',
-          paddingRight: '2.5em'
-        }}
-        // This will be the submit button defined at the bottom of the transitions (in line with the final input).
-        // If this is not the case, call halil.
-      />
-      <SubmitButton onClick={save}>
-        <CornerDownLeft size="18px" />
-      </SubmitButton>
-    </InputWrapper>
-  </>
-      )}
-    </Dropdown>
-    )
-    // Else if the project type is a PDA, do the following
+    if (dialog.type === 'TMtransition') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+            if (dialog.previousValue === undefined) {
+              removeTransitions([dialog.id])
+            }
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <Input
+              ref={inputRef}
+              value={read}
+              onChange={e => handleReadIn(e)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'λ\t(read)'}
+              style={{
+                width: 'calc(12ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+          </InputWrapper>
+          <InputWrapper>
+            <Input
+              ref={inputWriteRef}
+              value={write}
+              onChange={handleWriteIn}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'λ\t(write)'}
+              style={{
+                width: 'calc(12ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+          </InputWrapper>
+          <InputWrapper>
+            <Input
+              ref={inputDirectionRef}
+              value={direction}
+              onChange={handleDirectionIn}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'↔\t(direction)'}
+              style={{
+                width: 'calc(12ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else if (dialog.type === 'comment') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <MessageSquare style={{ marginInline: '1em .6em' }} />
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={'Comment text...'}
+              style={{
+                width: 'calc(20ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else if (dialog.type === 'state') {
+      return (
+        <Dropdown
+          visible={dialog.visible}
+          onClose={() => {
+            hideDialog()
+          }}
+          style={{
+            top: `${dialog.y}px`,
+            left: `${dialog.x}px`
+          }}
+        >
+          <InputWrapper>
+            <Type style={{ marginInline: '1em .6em' }} />
+            <Input
+              ref={inputRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              onKeyUp={e => e.key === 'Enter' && save()}
+              placeholder={{
+                stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
+                stateLabel: 'State label...'
+              }[dialog.placeholderType]}
+              style={{
+                width: 'calc(20ch + 3.5em)',
+                margin: '0 .4em',
+                paddingRight: '2.5em'
+              }}
+            />
+            <SubmitButton onClick={save}>
+              <CornerDownLeft size="18px" />
+            </SubmitButton>
+          </InputWrapper>
+        </Dropdown>
+      )
+    }
+    else {
+      return null;
+    }
   } else if (isPDA) {
     return (
       <Dropdown

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -380,9 +380,9 @@ const InputDialogs = () => {
       </>
           )}
       </Dropdown>
-    )}
-  // Else we assume the project type is a FSA, if we're adding more automaton then we will have to make more if statements, one for each automaton to define the logic and formatting of transitions and comments.
-  else {
+    )
+    // Else we assume the project type is a FSA, if we're adding more automaton then we will have to make more if statements, one for each automaton to define the logic and formatting of transitions and comments.
+  } else {
     return (
       <Dropdown
         visible={dialog.visible}

--- a/frontend/src/components/InputDialogs/InputDialogs.js
+++ b/frontend/src/components/InputDialogs/InputDialogs.js
@@ -193,7 +193,8 @@ const InputDialogs = () => {
     setDirection(value)
   }
 
-  if (projectType === 'TM') {
+  const isTM = projectType === 'TM'
+  if (isTM) {
     return (
     <Dropdown
       visible={dialog.visible}
@@ -209,54 +210,76 @@ const InputDialogs = () => {
         left: `${dialog.x}px`
       }}
     >
+        {(
+      <>
       <InputWrapper>
-        <Input
-          ref={inputRef}
-          value={read}
-          onChange={handleReadIn}
-          onKeyUp={e => e.key === 'Enter' && save()}
-          placeholder={'λ\t(read)'}
-          style={{
-            width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-            margin: '0 .4em',
-            paddingRight: '2.5em'
-          }}
-        />
-      </InputWrapper>
-      <InputWrapper>
-        <Input
-          ref={inputWriteRef}
-          value={write}
-          onChange={handleWriteIn}
-          onKeyUp={e => e.key === 'Enter' && save()}
-          placeholder={'λ\t(write)'}
-          style={{
-            width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-            margin: '0 .4em',
-            paddingRight: '2.5em'
-          }}
-        />
-      </InputWrapper>
-      <InputWrapper>
-        <Input
-          ref={inputDirectionRef}
-          value={direction}
-          onChange={handleDirectionIn}
-          onKeyUp={e => e.key === 'Enter' && save()}
-          placeholder={'↔\t(direction)'}
-          style={{
-            width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
-            margin: '0 .4em',
-            paddingRight: '2.5em'
-          }}
-        />
-        <SubmitButton onClick={save} disabled={!direction}>
-          <CornerDownLeft size="18px" />
-        </SubmitButton>
-      </InputWrapper>
+          {dialog.type === 'comment' && <MessageSquare style={{ marginInline: '1em .6em' }} />}
+          <Input
+            ref={inputRef}
+            value={dialog.type === 'comment' ? value : read}
+            onChange={(e) => dialog.type === 'comment' ? setValue(e.target.value) : handleReadIn(e)}
+            onKeyUp={(e) => e.key === 'Enter' && save()}
+            placeholder={{
+              TMtransition: 'λ\t(read)',
+              comment: 'Comment text...',
+              stateName: `${statePrefix ?? 'q'}${dialog.selectedState?.id ?? '0'}`,
+              stateLabel: 'State label...'
+            }[dialog.type]}
+            style={{
+              width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
+              margin: '0 .4em',
+              paddingRight: '2.5em'
+            }}
+          />
+          {!isTM || dialog.type !== 'TMtransition'
+            ? (
+              <SubmitButton onClick={save}>
+                <CornerDownLeft size="18px" />
+              </SubmitButton>
+              )
+            : null}
+        </InputWrapper>
+        </>
+        )}
+      {dialog.type === 'TMtransition' && (
+  <>
+    <InputWrapper>
+      <Input
+        ref={inputWriteRef}
+        value={write}
+        onChange={handleWriteIn}
+        onKeyUp={e => e.key === 'Enter' && save()}
+        placeholder={'λ\t(write)'}
+        style={{
+          width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
+          margin: '0 .4em',
+          paddingRight: '2.5em'
+        }}
+      />
+    </InputWrapper>
+    <InputWrapper>
+      <Input
+        ref={inputDirectionRef}
+        value={direction}
+        onChange={handleDirectionIn}
+        onKeyUp={e => e.key === 'Enter' && save()}
+        placeholder={'↔\t(direction)'}
+        style={{
+          width: `calc(${dialog.type === 'comment' ? '20ch' : '12ch'} + 3.5em)`,
+          margin: '0 .4em',
+          paddingRight: '2.5em'
+        }}
+      />
+      <SubmitButton onClick={save}>
+        <CornerDownLeft size="18px" />
+      </SubmitButton>
+    </InputWrapper>
+  </>
+      )}
     </Dropdown>
     )
-  } else {
+  }
+ else {
     const isPDA = projectType === 'PDA'
     return (
       <Dropdown


### PR DESCRIPTION
This fixes an issue with the PDA comment modals such that they no longer display the incorrect number of input fields (used to display three, now displays only one). On top of this, TM comment modals were fixed such that it is now no longer just the transition inputs and is now a proper comment modal. File was also tidied up to make future viewing easier.