### PR TITLE
Display Stack fix

### DIFF
--- a/frontend/src/components/PDAStackVisualiser/stackVisualiser.js
+++ b/frontend/src/components/PDAStackVisualiser/stackVisualiser.js
@@ -46,7 +46,7 @@ const PDAStackVisualiser = () => {
           className="close-stack-btn"
           onClick={() => setShowStackTab((e) => !e)}
         >
-          x
+          {showStackTab ? '-' : '+' }
         </button>
         {/* =========== Displays the stack =========== */}
         {showStackTab


### PR DESCRIPTION
### Overview ### 
Display Stack symbol has been replaced with a + and - .

###Solution ### 

- {showStackTab ? '-' : '+' }

### Demo ### 
![image](https://user-images.githubusercontent.com/127168662/229511623-f24db395-21e9-4c00-81ad-f28526d8653e.png)

![image](https://user-images.githubusercontent.com/127168662/229518519-2f1eae43-287a-45fe-ab0d-f0ddd33f3f6e.png)

![image](https://user-images.githubusercontent.com/127168662/229518694-8f592201-8702-411a-8018-92cc172d0fb6.png)






