### PR TITLE
Fixes running into `config` being undefined when loading fresh site

### DIFF
--- a/frontend/src/stores/useProjectStore.ts
+++ b/frontend/src/stores/useProjectStore.ts
@@ -94,13 +94,11 @@ interface ProjectStore {
 }
 
 const useProjectStore = create<ProjectStore>(persist((set: SetState<ProjectStore>, get: GetState<ProjectStore>) => ({
-  // Need to refactor to do this in a better way
-  project: {} as StoredProject,
+  project: null as StoredProject,
   history: [],
-  // yucky initial vals for numbers also need to refactor later on
-  historyPointer: 0,
-  lastChangeDate: -1,
-  lastSaveDate: -1,
+  historyPointer: null,
+  lastChangeDate: null,
+  lastSaveDate: null,
 
   set: (project: StoredProject) => { set({ project, history: [clone(project)], historyPointer: 0 }) },
 


### PR DESCRIPTION
Discovered problem in #324 (If you try and view the deployment there you will see the problem)

The values need to be null or else it doesn't think they need to be initialised (i.e. it will save the values which means it can't access properties like config since its an empty object)