### PR TITLE
Update `zustand`

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "react-hook-form": "^7.28.1",
     "react-lottie-player": "^1.4.3",
     "react-router-dom": "^6.2.2",
-    "zustand": "^3.7.1"
+    "zustand": "^4.3.7"
   },
   "devDependencies": {
     "@parcel/transformer-inline-string": "^2.8.3",

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import create from 'zustand'
+import { create } from 'zustand'
 
 import { firebase } from '/src/auth'
 import { getUser } from '/src/services/user'

--- a/frontend/src/hooks/useDibEgg.js
+++ b/frontend/src/hooks/useDibEgg.js
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import COLORS from '/src/config/colors'
 
 // Store state of easter egg across site instance

--- a/frontend/src/stores/useExportStore.ts
+++ b/frontend/src/stores/useExportStore.ts
@@ -1,4 +1,4 @@
-import create, { SetState } from 'zustand'
+import { create, SetState } from 'zustand'
 
 interface Options {
   filename: string

--- a/frontend/src/stores/usePDAVisualiserStore.ts
+++ b/frontend/src/stores/usePDAVisualiserStore.ts
@@ -1,4 +1,4 @@
-import create, { SetState } from 'zustand'
+import { create, SetState } from 'zustand'
 
 interface PDAVisualiserStore {
   stack: Record<string, string[]>

--- a/frontend/src/stores/usePreferencesStore.ts
+++ b/frontend/src/stores/usePreferencesStore.ts
@@ -1,4 +1,4 @@
-import create, { SetState } from 'zustand'
+import { create, SetState } from 'zustand'
 import { persist } from 'zustand/middleware'
 
 interface Preferences {
@@ -20,7 +20,7 @@ const defaultPreferences: Preferences = {
   ctrlZoom: !navigator.platform?.match(/Win/) // Default to false on windows, which more often has a mouse
 }
 
-const usePreferencesStore = create<PreferencesStore>(persist((set: SetState<PreferencesStore>) => ({
+const usePreferencesStore = create<PreferencesStore>()(persist((set: SetState<PreferencesStore>) => ({
   preferences: { ...defaultPreferences },
   setPreferences: (preferences: Preferences) => set({ preferences })
 }), {

--- a/frontend/src/stores/useProjectStore.ts
+++ b/frontend/src/stores/useProjectStore.ts
@@ -1,4 +1,4 @@
-import create, { SetState, GetState } from 'zustand'
+import { create, SetState, GetState } from 'zustand'
 import { persist } from 'zustand/middleware'
 import produce, { current } from 'immer'
 import clone from 'lodash.clonedeep'
@@ -98,7 +98,7 @@ interface ProjectStore {
   reset: () => void
 }
 
-const useProjectStore = create<ProjectStore>(persist((set: SetState<ProjectStore>, get: GetState<ProjectStore>) => ({
+const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectStore>, get: GetState<ProjectStore>) => ({
   project: null as StoredProject,
   history: [],
   historyPointer: null,

--- a/frontend/src/stores/useProjectsStore.ts
+++ b/frontend/src/stores/useProjectsStore.ts
@@ -1,4 +1,4 @@
-import create, { SetState } from 'zustand'
+import { create, SetState } from 'zustand'
 import { persist } from 'zustand/middleware'
 import { StoredProject } from './useProjectStore'
 
@@ -10,7 +10,7 @@ interface ProjectsStore {
   deleteProject: (pid: string) => void,
 }
 
-const useProjectsStore = create<ProjectsStore>(persist((set: SetState<ProjectsStore>) => ({
+const useProjectsStore = create<ProjectsStore>()(persist((set: SetState<ProjectsStore>) => ({
   projects: [] as StoredProject[],
   setProjects: (projects: StoredProject[]) => set({ projects }),
   clearProjects: () => set({ projects: [] }),

--- a/frontend/src/stores/useSelectionStore.ts
+++ b/frontend/src/stores/useSelectionStore.ts
@@ -1,4 +1,4 @@
-import create, { SetState } from 'zustand'
+import { create, SetState } from 'zustand'
 import { useProjectStore } from '/src/stores'
 
 type SelectionStore = {

--- a/frontend/src/stores/useSteppingStore.js
+++ b/frontend/src/stores/useSteppingStore.js
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 // import produce, { current } from "immer";
 
 const useSteppingStore = create((set) => ({

--- a/frontend/src/stores/useTMSimResultStore.js
+++ b/frontend/src/stores/useTMSimResultStore.js
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import produce from 'immer'
 // import produce, { current } from "immer";
 

--- a/frontend/src/stores/useThumbnailStore.js
+++ b/frontend/src/stores/useThumbnailStore.js
@@ -1,7 +1,7 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-const useThumbnailStore = create(persist(set => ({
+const useThumbnailStore = create()(persist(set => ({
   thumbnails: {},
 
   setThumbnail: (id, thumbnail) => set(state => ({

--- a/frontend/src/stores/useToolStore.js
+++ b/frontend/src/stores/useToolStore.js
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 
 const useToolStore = create(set => ({
   tool: 'cursor',

--- a/frontend/src/stores/useViewStore.js
+++ b/frontend/src/stores/useViewStore.js
@@ -1,4 +1,4 @@
-import create from 'zustand'
+import { create } from 'zustand'
 import produce from 'immer'
 
 const screenToCanvasSpace = (x, y, container) => {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -10,7 +10,6 @@
     "paths": {
       "/src/*": ["./src/*"]
     },
-    "skipLibCheck": true
   },
   "include": [
     "src/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11829,6 +11829,11 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+use-sync-external-store@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
+
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -12241,7 +12246,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@^3.7.1:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-3.7.2.tgz#7b44c4f4a5bfd7a8296a3957b13e1c346f42514d"
-  integrity sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==
+zustand@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.3.7.tgz#501b1f0393a7f1d103332e45ab574be5747fedce"
+  integrity sha512-dY8ERwB9Nd21ellgkBZFhudER8KVlelZm8388B5nDAXhO/+FZDhYMuRnqDgu5SYyRgz/iaf8RKnbUs/cHfOGlQ==
+  dependencies:
+    use-sync-external-store "1.2.0"


### PR DESCRIPTION
Closes #329 

This updates zustand to 4.x.x which brings better typescript support. This means we can reenable lib checking which stronger type checking

Turns out the issues that needed to be fixed were a lot less than what the red lines in my IDE were saying