### PR TITLE
Fix height differences in new project cards

### DIFF
--- a/frontend/src/pages/NewFile/NewFile.tsx
+++ b/frontend/src/pages/NewFile/NewFile.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { convertJFLAPXML } from '@automatarium/jflap-translator'
 import dayjs from 'dayjs'
@@ -30,6 +30,14 @@ const NewFile = () => {
   const [loginModalVisible, setLoginModalVisible] = useState(false)
   const [signupModalVisible, setSignupModalVisible] = useState(false)
   const { user, loading } = useAuth()
+  // We find the tallest card using method shown here
+  // https://legacy.reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
+  const [height, setHeight] = useState(0)
+  const cardsRef = useCallback((node: HTMLDivElement) => {
+    if (node === null) return
+    // Get the height of the tallest card, we will set the rest of the cards to it
+    setHeight(Math.max(...[...node.children].map(it => it.getBoundingClientRect().height)))
+  }, [])
 
   // Dynamic styling values for new project thumbnails
   // Will likely be extended to 'Your Projects' list
@@ -121,23 +129,27 @@ const NewFile = () => {
     <CardList
       title="New Project"
       button={<Button onClick={importProject}>Import...</Button>}
+      innerRef={cardsRef}
     >
       <NewProjectCard
         title="Finite State Automaton"
         description="Create a deterministic or non-deterministic automaton with finite states. Capable of representing regular grammars."
         onClick={() => handleNewFile('FSA')}
+        height={height}
         image={<FSA {...stylingVals}/>}
       />
       <NewProjectCard
         title="Push Down Automaton"
         description="Create an automaton with a push-down stack capable of representing context-free grammars."
         onClick={() => handleNewFile('PDA')}
+        height={height}
         image={<PDA {...stylingVals}/>}
       />
       <NewProjectCard
         title="Turing Machine"
         description="Create a turing machine capable of representing recursively enumerable grammars."
         onClick={() => handleNewFile('TM')}
+        height={height}
         image={<TM {...stylingVals}/>}
       />
     </CardList>

--- a/frontend/src/pages/NewFile/components/CardList/CardList.tsx
+++ b/frontend/src/pages/NewFile/components/CardList/CardList.tsx
@@ -1,9 +1,10 @@
 import { CardListContainer, CardListTitleContainer, CardListTitle } from './cardListStyle'
-import { HTMLAttributes, ReactNode } from 'react'
+import { HTMLAttributes, ReactNode, Ref } from 'react'
 
 interface CardListProps extends HTMLAttributes<HTMLDivElement> {
   title: string
   button?: ReactNode
+  innerRef?: Ref<HTMLDivElement>
 }
 
 const CardList = ({ title, button, ...props }: CardListProps) => (
@@ -12,7 +13,7 @@ const CardList = ({ title, button, ...props }: CardListProps) => (
       {title && <CardListTitle>{title}</CardListTitle>}
       {button}
     </CardListTitleContainer>
-    <CardListContainer {...props} />
+    <CardListContainer ref={props.innerRef} {...props} />
   </section>
 )
 

--- a/frontend/src/pages/NewFile/components/CardList/cardListStyle.ts
+++ b/frontend/src/pages/NewFile/components/CardList/cardListStyle.ts
@@ -1,4 +1,5 @@
 import { styled } from 'goober'
+import { forwardRef } from 'react'
 
 export const CardListTitleContainer = styled('div')`
   display: flex;
@@ -11,7 +12,7 @@ export const CardListTitle = styled('h2')`
   margin-block: 0;
 `
 
-export const CardListContainer = styled('div')`
+export const CardListContainer = styled('div', forwardRef)`
   display: flex;
   gap: .4em;
   margin-block-start: 1em;

--- a/frontend/src/pages/NewFile/components/NewProjectCard/NewProjectCard.tsx
+++ b/frontend/src/pages/NewFile/components/NewProjectCard/NewProjectCard.tsx
@@ -1,12 +1,22 @@
 import { CardContainer, CardImage, CardContent } from './newProjectCardStyle'
 import { usePreferencesStore } from '/src/stores'
+import { ReactNode } from 'react'
 
-const NewProjectCard = ({ title, description, image, ...props }) => {
+interface NewProjectCardProps {
+  title: string
+  description: string
+  image: ReactNode
+  onClick: () => void
+  height: number
+  disabled?: boolean
+}
+
+const NewProjectCard = ({ title, description, image, height, ...props }: NewProjectCardProps) => {
   const preferences = usePreferencesStore(state => state.preferences)
   // If matching system theme, don't append a theme to css vars
   const theme = preferences.theme === 'system' ? '' : `-${preferences.theme}`
   return (
-    <CardContainer {...props}>
+    <CardContainer height={height} {...props}>
       <CardImage $disabled={props.disabled} theme={theme}>{image}</CardImage>
       <CardContent>
         <strong>{title}</strong>

--- a/frontend/src/pages/NewFile/components/NewProjectCard/newProjectCardStyle.ts
+++ b/frontend/src/pages/NewFile/components/NewProjectCard/newProjectCardStyle.ts
@@ -1,12 +1,13 @@
 import { styled } from 'goober'
 
-export const CardContainer = styled('button')`
+export const CardContainer = styled('button')<{height: number}>`
   display: grid;
   grid-template-rows: 1.3fr 1fr;
   box-sizing: border-box;
   min-width: 18em;
   width: 20em;
-
+  height: ${p => p.height || '100%'}px;
+  
   border-radius: .5rem;
   border: 3px solid transparent;
   overflow: hidden;

--- a/frontend/src/pages/NewFile/components/NewProjectCard/newProjectCardStyle.ts
+++ b/frontend/src/pages/NewFile/components/NewProjectCard/newProjectCardStyle.ts
@@ -6,6 +6,7 @@ export const CardContainer = styled('button')<{height: number}>`
   box-sizing: border-box;
   min-width: 18em;
   width: 20em;
+  // Default to 100% if anything wrong happens so its still viewable
   height: ${p => p.height || '100%'}px;
   
   border-radius: .5rem;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -12,7 +12,7 @@
     "paths": {
       "/src/*": ["./src/*"]
     },
-    "lib": ["DOM", "ES2021"],
+    "lib": ["DOM", "ES2021", "dom.iterable"],
     "outDir": "dist/"
   },
   "include": [


### PR DESCRIPTION
Closes #299 

![image](https://user-images.githubusercontent.com/19339842/232353723-b89f7e35-c5f2-4832-a572-9e0e2f947667.png)


Reason I'm doing the issue is because I was only able to reproduce on my laptop

The root cause seemed to be font sizes. My chrome had a smaller font size so it could fit everything but my Firefox uses my system font which is a bit bigger so took more space in the first card. This makes the cards be based relative to the size of the fonts and should allow for roughly ~5 lines of text per card.

Requested multiple reviewers so that it can be tested on different font sizes and computers to make sure the changes don't cause weirdness for anyone else