### PR TITLE
Don't reorder when no initial state

### DIFF
--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -454,7 +454,7 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     REORDER_GRAPH: {
-      disabled: () => project.initialState !== null,
+      disabled: () => project.initialState === null,
       handler: () => {
         updateProject(reorderStates(project))
         commit()

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -454,6 +454,7 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     REORDER_GRAPH: {
+      disabled: () => project.initialState !== null,
       handler: () => {
         updateProject(reorderStates(project))
         commit()

--- a/packages/simulation/src/reorder.ts
+++ b/packages/simulation/src/reorder.ts
@@ -10,9 +10,10 @@ import { Queue } from './collection'
  * This is performed by using a combination of breath and depth searches. If there is only a single path to take then it
  * goes depth first. If there are multiple branches then it adds them to the queue so it goes back to breath first.
  * i.e. This is a fancy floodfill
- * @param graph Graph to reorder. This is performed in-place
+ * @param graph Graph to reorder
  */
 export const reorderStates = (graph: UnparsedGraph): UnparsedGraph => {
+  if (graph.initialState === null) return graph
   // Convert the graph into an adjacency list of transitions
   const graphList: {[key: number]: number[]} = {}
   graph.transitions.forEach(x => {

--- a/packages/simulation/tests/reorderGraph.test.ts
+++ b/packages/simulation/tests/reorderGraph.test.ts
@@ -53,6 +53,37 @@ describe('Reordering graph', () => {
     })
   })
 
+  test('Nothing happens when no initial state', () => {
+    const graph = {
+      states: [
+        {
+          isFinal: true,
+          x: 570,
+          y: 255,
+          id: 0
+        },
+        {
+          isFinal: false,
+          x: 405,
+          y: 255,
+          id: 1
+        }
+      ],
+      transitions: [
+        {
+          from: 1,
+          to: 0,
+          id: 0,
+          write: '',
+          direction: 'R',
+          read: ''
+        }
+      ],
+      initialState: null
+    } as unknown as UnparsedGraph
+    expect(reorderStates(graph)).toEqual(graph)
+  })
+
   test('Cycles are handled', () => {
     let testVer = JSON.parse(JSON.stringify(dibDipLambdaLoop)) as UnparsedGraph
     testVer = reorderStates(testVer)


### PR DESCRIPTION
This disables the reordering action when there is no initial state instead of just treating `q0` as the initial and working from that.

It disables it in the frontend, and just does an early return in the function incase it is used elsewhere