### PR TITLE
Fix typescript linting

### DIFF
--- a/eslintConfig.json
+++ b/eslintConfig.json
@@ -3,7 +3,9 @@
     "es2021": true
   },
   "extends": [
-    "standard"
+    "standard",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
@@ -14,6 +16,7 @@
     "@typescript-eslint"
   ],
   "rules": {
-    "import/no-absolute-path": "off"
+    "import/no-absolute-path": "off",
+    "@typescript-eslint/no-unused-vars": "error"
   }
 }

--- a/frontend/src/components/BottomPanel/BottomPanel.js
+++ b/frontend/src/components/BottomPanel/BottomPanel.js
@@ -22,7 +22,7 @@ const BottomPanel = () => {
     setActivePanel(activePanel?.value === panel.value ? undefined : panel)
   }, [activePanel])
 
-  useEvent('bottomPanel:close', e => {
+  useEvent('bottomPanel:close', () => {
     setActivePanel(undefined)
   }, [activePanel])
 

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.js
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.js
@@ -66,9 +66,9 @@ const SteppingLab = () => {
           />
         </ButtonRow>
         <ButtonRow>
-          <Button icon={<Snowflake size={23} />} onClick={() => {}} />
-          <Button icon={<Flame size={23} />} onClick={() => {}} />
-          <Button icon={<XCircle size={23} />} onClick={() => {}} />
+          <Button icon={<Snowflake size={23} />}/>
+          <Button icon={<Flame size={23} />} />
+          <Button icon={<XCircle size={23} />}/>
         </ButtonRow>
       </Wrapper>
     </>

--- a/frontend/src/config/index.ts
+++ b/frontend/src/config/index.ts
@@ -1,6 +1,6 @@
-const env = process.env.NODE_ENV || 'development'
+import firebaseConfigDev from './firebase-config-dev.json'
 
-const firebaseConfigDev = require('./firebase-config-dev.json')
+const env = process.env.NODE_ENV || 'development'
 
 const config = {
   development: {

--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -82,7 +82,7 @@ const useActions = (registerHotkeys = false) => {
       hotkey: { key: 's', shift: true, meta: true },
       handler: () => {
         // Pull project state
-        const { project: { _id, userid, ...project } } = useProjectStore.getState()
+        const project = useProjectStore.getState()
 
         // Create a download link and use it
         const a = document.createElement('a')

--- a/frontend/src/hooks/useDeleteTool.js
+++ b/frontend/src/hooks/useDeleteTool.js
@@ -28,7 +28,7 @@ const useDeleteTool = () => {
   })
 
   // On mouse up deletes the previously selected state
-  useEvent('state:mouseup', e => {
+  useEvent('state:mouseup', () => {
     if (tool === 'delete') {
       removeStates(selectedStates)
       selectNone()
@@ -45,7 +45,7 @@ const useDeleteTool = () => {
   })
 
   // On mouseup deletes the previously selected (mousedown) transition
-  useEvent('transition:mouseup', e => {
+  useEvent('transition:mouseup', () => {
     if (tool === 'delete') {
       removeTransitions(selectedTransitions)
       selectNone()
@@ -58,7 +58,7 @@ const useDeleteTool = () => {
     if (tool === 'delete') setSelectedComments(selectedCommentIDs)
   })
 
-  useEvent('comment:mouseup', e => {
+  useEvent('comment:mouseup', () => {
     if (tool === 'delete') {
       removeComments(selectedComments)
       selectNone()

--- a/frontend/src/stores/useThumbnailStore.js
+++ b/frontend/src/stores/useThumbnailStore.js
@@ -8,6 +8,7 @@ const useThumbnailStore = create()(persist(set => ({
     thumbnails: { ...state.thumbnails, [id]: thumbnail }
   })),
   removeThumbnail: id => set(state => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { [id]: removed, ...thumbnails } = state.thumbnails
     return { thumbnails }
   }),

--- a/frontend/src/types/ProjectTypes.ts
+++ b/frontend/src/types/ProjectTypes.ts
@@ -145,6 +145,7 @@ export type CopyData = {
  * Small helper function to change the value of a type at block level.
  * Use this with care since it does override the type system.
  */
+// eslint-disable-next-line @typescript-eslint/no-empty-function
 export function assertType<T> (value: unknown): asserts value is T {
 
 }

--- a/packages/jflap-translator/src/convertJFLAP.ts
+++ b/packages/jflap-translator/src/convertJFLAP.ts
@@ -1,4 +1,4 @@
-import { xml2json } from 'xml-js'
+import { ElementCompact, xml2js } from 'xml-js'
 
 import { DEFAULT_PROJECT_COLOR, DEFAULT_STATE_PREFIX, DEFAULT_ACCEPTANCE_CRITERIA, SCHEMA_VERSION, APP_VERSION } from 'frontend/src/config/projects'
 import {
@@ -16,13 +16,12 @@ const PROJECT_TYPE_MAP: Record<string, ProjectType> = {
 
 // Convert JFLAP XML to Automatarium format
 export const convertJFLAPXML = (xml: string): Project => {
-  const json = xml2json(xml, { compact: true, ignoreComment: true, ignoreDeclaration: true })
-  const jflapProject = JSON.parse(json)
+  const jflapProject = xml2js(xml, { compact: true, ignoreComment: true, ignoreDeclaration: true })
   return convertJFLAPProject(jflapProject)
 }
 
 // Convert JFLAP JSON to Automatarium format
-export const convertJFLAPProject = (jflapProject: any): Project => {
+export const convertJFLAPProject = (jflapProject: ElementCompact): Project => {
   // Pull out necessary values from jflap project
   let {
     structure: {
@@ -38,7 +37,7 @@ export const convertJFLAPProject = (jflapProject: any): Project => {
   }
 
   // Convert attributes to arrays if they are not already
-  const toArray = (x: any[]) => x === undefined ? [] : (Array.isArray(x) ? x : [x])
+  const toArray = <T>(x: T[]): T[] => x === undefined ? [] : (Array.isArray(x) ? x : [x])
   states = toArray(states)
   transitions = toArray(transitions)
   notes = toArray(notes)

--- a/packages/simulation/src/Step.ts
+++ b/packages/simulation/src/Step.ts
@@ -12,7 +12,7 @@ export class GraphStepper<S extends State, T extends BaseAutomataTransition> {
     const frontierCopy = this.frontier.slice()
     this.frontier = []
     while (frontierCopy.length > 0) {
-      const node = frontierCopy.shift()!
+      const node = frontierCopy.shift()
       for (const successor of this.graph.getSuccessors(node)) {
         this.frontier.push(successor)
       }

--- a/packages/simulation/src/convert.ts
+++ b/packages/simulation/src/convert.ts
@@ -225,7 +225,7 @@ export function createSymbolFromEveryState (initialTransitionTable: TransitionTa
             const symbolFound = initialTransitionTable[stateID].some(([, readSymbol]) => readSymbol === symbol)
             // If symbol isn't found then transition to the defined trap state
             if (!symbolFound) {
-              const existingTransition = initialTransitionTable[stateID].find(([toStateID, readSymbol]) => readSymbol === symbol)
+              const existingTransition = initialTransitionTable[stateID].find(([, readSymbol]) => readSymbol === symbol)
               if (!existingTransition) {
                 initialTransitionTable[stateID].push([nextAvailableStateID, symbol])
               } else {
@@ -239,7 +239,7 @@ export function createSymbolFromEveryState (initialTransitionTable: TransitionTa
             const symbolFound = initialTransitionTable[stateID].some(([, readSymbol]) => readSymbol === symbol)
             if (!symbolFound) {
               // Check if a transition already exists for this symbol
-              const existingTransition = initialTransitionTable[stateID].find(([toStateID, readSymbol]) => readSymbol === symbol)
+              const existingTransition = initialTransitionTable[stateID].find(([, readSymbol]) => readSymbol === symbol)
               // If not, then make a transition to the next state for this symbol for the current state
               if (!existingTransition) {
                 initialTransitionTable[stateID].push([nextAvailableStateID, symbol])
@@ -528,8 +528,7 @@ export const convertNFAtoDFA = (nfaGraph: FSAProjectGraph): FSAProjectGraph => {
       // Remove unreachable states from this new dfaGraph
       dfaGraph = removeUnreachableStates(dfaGraph)
       // Finally copy over the required elements from nfaGraph and return the final dfaGraph
-      const { initialState, states, transitions, ...dfaGraphCopy } = nfaGraph
-      return { ...dfaGraph, ...dfaGraphCopy }
+      return dfaGraph
     }
   }
 }

--- a/packages/simulation/src/search.ts
+++ b/packages/simulation/src/search.ts
@@ -15,7 +15,7 @@ export const breadthFirstSearch = <S extends State, T extends BaseAutomataTransi
 
   while (!frontier.isEmpty()) {
     // Bang is necessary because TS doesn't understand that the frontier is not empty here
-    node = frontier.remove()!
+    node = frontier.remove()
     if (graph.isFinalState(node)) {
       return node
     }

--- a/packages/simulation/src/validTransitions.ts
+++ b/packages/simulation/src/validTransitions.ts
@@ -1,7 +1,7 @@
 import { ReadSymbol, StateID } from './graph'
 import closureWithPredicate from './closureWithPredicate'
-import { BaseAutomataTransition, ProjectType } from 'frontend/src/types/ProjectTypes'
-import { RestrictedProject, TransitionMapping } from './utils'
+import { BaseAutomataTransition, ProjectGraph } from 'frontend/src/types/ProjectTypes'
+import { TransitionMapping } from './utils'
 
 export type ValidTransition<T extends BaseAutomataTransition> = { transition: T, trace: { to: number, read: string }[]}
 
@@ -14,7 +14,7 @@ export type ValidTransition<T extends BaseAutomataTransition> = { transition: T,
  * @param nextRead  - The input symbol to be read next
  * @returns A list of transitions and the "trace" of states and symbols required to navigate it.
  */
-export const validTransitions = <P extends ProjectType, T extends TransitionMapping[P]>(graph: RestrictedProject<P>, currentStateID: StateID, nextRead: ReadSymbol): ValidTransition<T>[] => {
+export const validTransitions = <P extends ProjectGraph, T extends TransitionMapping<P>>(graph: P, currentStateID: StateID, nextRead: ReadSymbol): ValidTransition<T>[] => {
   // Compute lambda closure (states accessible without consuming input)
   const closure = Array.from(closureWithPredicate(graph, currentStateID, tr => tr.read.length === 0))
 

--- a/packages/simulation/tests/convertNFAtoDFA.test.ts
+++ b/packages/simulation/tests/convertNFAtoDFA.test.ts
@@ -16,55 +16,61 @@ import convertSingleTrapState from './graphs/convertSingleTrapState.json'
 import convertSingleTrapStateDFA from './graphs/convertSingleTrapStateDFA.json'
 import { FSAProjectGraph } from 'frontend/src/types/ProjectTypes'
 
-const convertToDFA = (project: FSAProjectGraph): FSAProjectGraph => {
-  return reorderStates(convertNFAtoDFA(reorderStates(project)))
+// Required because we can't do `as const` to the imported JSON.
+// Means we don't need `as FSAProjectGraph` everywhere
+type LooseFSA = Omit<FSAProjectGraph, 'projectType'> & {projectType: string}
+
+const convertToDFA = (project: LooseFSA): FSAProjectGraph => {
+  return reorderStates(convertNFAtoDFA(reorderStates(project as FSAProjectGraph)))
 }
 
 describe('Check to ensure NFA graph is valid before conversion begins', () => {
   test('Graph should not be processed for conversion if there are no final states', () => {
     expect(() => {
-      convertToDFA(convertFinalNotPresent as FSAProjectGraph)
+      convertToDFA(convertFinalNotPresent)
     }).toThrow('Error: Graph is not suitable for conversion. Please ensure that at least one final state is declared.')
   })
 
   test('Graph should not be processed for conversion if there are no initial states', () => {
     expect(() => {
-      convertToDFA(convertInitialNotPresent as FSAProjectGraph)
+      convertToDFA(convertInitialNotPresent)
     }).toThrow('Error: Graph is not suitable for conversion. Please ensure that an initial state is declared.')
   })
 
   test('Graph should not be processed for conversion if there are no states or transitions', () => {
     expect(() => {
-      convertToDFA(convertNoStatesOrTransitionsPresent as FSAProjectGraph)
+      convertToDFA(convertNoStatesOrTransitionsPresent)
     }).toThrow('Error: Graph is not suitable for conversion. Please ensure you have both states and transitions present.')
   })
 
   test('Graph should not be processed for conversion if there are no reachable final states', () => {
     expect(() => {
-      convertToDFA(convertFinalNotReachable as FSAProjectGraph)
+      convertToDFA(convertFinalNotReachable)
     }).toThrow('Error: Graph is not suitable for conversion. Please ensure your final state is able to be reached by the initial state.')
   })
 })
 
 describe('Check to ensure DFA graph is displayed as expected', () => {
+  const expectDFA = (nfa: LooseFSA, dfa: LooseFSA) => {
+    const graph = convertToDFA(nfa)
+    // Only compare fields that are in FSAProjectGraph
+    expect(graph.initialState).toEqual(dfa.initialState)
+    expect(graph.states).toEqual(dfa.states)
+    expect(graph.transitions).toEqual(dfa.transitions)
+  }
   test('Graph should be converted correctly to DFA under simple conditions (1 symbol)', () => {
-    const graph = convertToDFA(convertSimpleConversion as FSAProjectGraph)
-    expect(graph).toEqual(convertSimpleConversionDFA)
+    expectDFA(convertSimpleConversion, convertSimpleConversionDFA)
   })
   test('Graph should be converted correctly to DFA when initial state is not at the start', () => {
-    const graph = convertToDFA(convertInitialNotAtStart as FSAProjectGraph)
-    expect(graph).toEqual(convertInitialNotAtStartDFA)
+    expectDFA(convertInitialNotAtStart, convertInitialNotAtStartDFA)
   })
   test('Graph should be converted correctly to DFA with multiple final states', () => {
-    const graph = convertToDFA(convertMultipleFinal as FSAProjectGraph)
-    expect(graph).toEqual(convertMultipleFinalDFA)
+    expectDFA(convertMultipleFinal, convertMultipleFinalDFA)
   })
   test('Graph should be converted correctly to DFA under harder conditions (2 symbols)', () => {
-    const graph = convertToDFA(convertHarderConversion as FSAProjectGraph)
-    expect(graph).toEqual(convertHarderConversionDFA)
+    expectDFA(convertHarderConversion, convertHarderConversionDFA)
   })
   test('Graph should use a single trap state instead of multiple when converted to a DFA', () => {
-    const graph = convertToDFA(convertSingleTrapState as FSAProjectGraph)
-    expect(graph).toEqual(convertSingleTrapStateDFA)
+    expectDFA(convertSingleTrapState, convertSingleTrapStateDFA)
   })
 })

--- a/packages/simulation/tests/convertNFAtoDFA.test.ts
+++ b/packages/simulation/tests/convertNFAtoDFA.test.ts
@@ -65,7 +65,7 @@ describe('Check to ensure DFA graph is displayed as expected', () => {
     expect(graph.transitions[2].to).toBe(2)
   })
   test('Graph should be converted correctly to DFA when initial state is not at the start', () => {
-    const graph = reorderStates(convertNFAtoDFA(reorderStates(convertInitialNotAtStart as any) as any) as any)
+    const graph = convertToDFA(convertInitialNotAtStart as FSAProjectGraph)
     // Initial state should be q0
     expect(graph.initialState).toBe(0)
     // They would be 3 if they got returned as a DFA rather than 4 as an NFA


### PR DESCRIPTION
Fixes the issue found in #348 where the linter considered a used enum to be unused.
Does this by using the recommended typescript rules which properly account for that.

This also meant that quite a few files needed to be updated because things that previously weren't caught are now caught (e.g. explicit `any` isn't allowed anymore)

The biggest change is is `utils.ts` where the `buildProblem` function I made needed to be cleaned up. The changes to it are a lot nicer since now the type inference gets the return type correct is most cases now. The clean up to the mapper types also means making generics for the simulator are a lot nicer