### PR TITLE
Clean up presentation of convert tests

### DIFF
--- a/packages/simulation/tests/convertNFAtoDFA.test.ts
+++ b/packages/simulation/tests/convertNFAtoDFA.test.ts
@@ -5,10 +5,15 @@ import convertInitialNotPresent from './graphs/convertInitialNotPresent.json'
 import convertNoStatesOrTransitionsPresent from './graphs/convertNoStatesOrTransitionsPresent.json'
 import convertFinalNotReachable from './graphs/convertFinalNotReachable.json'
 import convertSimpleConversion from './graphs/convertSimpleConversion.json'
+import convertSimpleConversionDFA from './graphs/convertSimpleConversionDFA.json'
 import convertHarderConversion from './graphs/convertHarderConversion.json'
+import convertHarderConversionDFA from './graphs/convertHarderConversionDFA.json'
 import convertMultipleFinal from './graphs/convertMultipleFinal.json'
+import convertMultipleFinalDFA from './graphs/convertMultipleFinalDFA.json'
 import convertInitialNotAtStart from './graphs/convertInitialNotAtStart.json'
+import convertInitialNotAtStartDFA from './graphs/convertInitialNotAtStartDFA.json'
 import convertSingleTrapState from './graphs/convertSingleTrapState.json'
+import convertSingleTrapStateDFA from './graphs/convertSingleTrapStateDFA.json'
 import { FSAProjectGraph } from 'frontend/src/types/ProjectTypes'
 
 const convertToDFA = (project: FSAProjectGraph): FSAProjectGraph => {
@@ -44,173 +49,22 @@ describe('Check to ensure NFA graph is valid before conversion begins', () => {
 describe('Check to ensure DFA graph is displayed as expected', () => {
   test('Graph should be converted correctly to DFA under simple conditions (1 symbol)', () => {
     const graph = convertToDFA(convertSimpleConversion as FSAProjectGraph)
-    // Initial state should be q0
-    expect(graph.initialState).toBe(0)
-    // They would be 3 if they got returned as a DFA rather than 4 as an NFA
-    expect(graph.states.length).toBe(3)
-    // Only q1 should be a final state
-    for (let curState = 0; curState < graph.states.length; curState++) {
-      if (curState === 1) {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
-      } else {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
-      }
-    }
-    // No lambda transition should be found, and should be 3 transitions total. All transitions should have symbol "A"
-    expect(graph.transitions.length).toBe(3)
-    const alphabet = 'A'
-    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
-    // Transitions should go in a straight line except the trap state, which goes to itself
-    expect(graph.transitions[0].from).toBe(0)
-    expect(graph.transitions[0].to).toBe(1)
-    expect(graph.transitions[1].from).toBe(1)
-    expect(graph.transitions[1].to).toBe(2)
-    expect(graph.transitions[2].from).toBe(2)
-    expect(graph.transitions[2].to).toBe(2)
+    expect(graph).toEqual(convertSimpleConversionDFA)
   })
   test('Graph should be converted correctly to DFA when initial state is not at the start', () => {
     const graph = reorderStates(convertNFAtoDFA(reorderStates(convertInitialNotAtStart as any) as any) as any)
-    // Initial state should be q0
-    expect(graph.initialState).toBe(0)
-    // They would be 3 if they got returned as a DFA rather than 4 as an NFA
-    expect(graph.states.length).toBe(3)
-    // Only q1 should be a final state
-    for (let curState = 0; curState < graph.states.length; curState++) {
-      if (curState === 1) {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
-      } else {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
-      }
-    }
-    // No lambda transition should be found, and should be 3 transitions total. All transitions should have symbol "A"
-    expect(graph.transitions.length).toBe(3)
-    const alphabet = 'A'
-    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
-    // Transitions should go in a straight line except the trap state, which goes to itself
-    expect(graph.transitions[0].from).toBe(0)
-    expect(graph.transitions[0].to).toBe(1)
-    expect(graph.transitions[1].from).toBe(1)
-    expect(graph.transitions[1].to).toBe(2)
-    expect(graph.transitions[2].from).toBe(2)
-    expect(graph.transitions[2].to).toBe(2)
+    expect(graph).toEqual(convertInitialNotAtStartDFA)
   })
   test('Graph should be converted correctly to DFA with multiple final states', () => {
     const graph = convertToDFA(convertMultipleFinal as FSAProjectGraph)
-    // Initial state should be q0
-    expect(graph.initialState).toBe(0)
-    // They would be 3 if they got returned as a DFA rather than 4 as an NFA
-    expect(graph.states.length).toBe(3)
-    // Both q0 and q1 should be final states
-    for (let curState = 0; curState < graph.states.length; curState++) {
-      if (curState === 0 || curState === 1) {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
-      } else {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
-      }
-    }
-    // No lambda transition should be found, and should be 3 transitions total. All transitions should have symbol "A"
-    expect(graph.transitions.length).toBe(3)
-    const alphabet = 'A'
-    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
-    // Transitions should go in a straight line except the trap state, which goes to itself
-    expect(graph.transitions[0].from).toBe(0)
-    expect(graph.transitions[0].to).toBe(1)
-    expect(graph.transitions[1].from).toBe(1)
-    expect(graph.transitions[1].to).toBe(2)
-    expect(graph.transitions[2].from).toBe(2)
-    expect(graph.transitions[2].to).toBe(2)
+    expect(graph).toEqual(convertMultipleFinalDFA)
   })
   test('Graph should be converted correctly to DFA under harder conditions (2 symbols)', () => {
     const graph = convertToDFA(convertHarderConversion as FSAProjectGraph)
-    // Initial state should be q0
-    expect(graph.initialState).toBe(0)
-    // They would be 6 if they got returned as a DFA rather than 4 as an NFA
-    expect(graph.states.length).toBe(6)
-    // Should be two final states, q2 and q3
-    for (let curState = 0; curState < graph.states.length; curState++) {
-      if (curState === 2 || curState === 3) {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
-      } else {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
-      }
-    }
-    // No lambda transition should be found, and should be 12 transitions total. All states should have a single transition 'A' and 'B' from, and be connected in a certain way
-    expect(graph.transitions.length).toBe(12)
-    const alphabet = 'AB'
-    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
-    // Transitions should be connected appropriately
-    expect(graph.transitions.filter((transition) => transition.from === 0).length).toBe(2)
-    expect(graph.transitions.filter((transition) => transition.from === 0)[0].to).toBeOneOf([1, 3])
-    expect(graph.transitions.filter((transition) => transition.from === 0)[0].read).toBeOneOf(['A', 'B'])
-    expect(graph.transitions.filter((transition) => transition.from === 0)[1].to).toBeOneOf([1, 3])
-    expect(graph.transitions.filter((transition) => transition.from === 0)[1].read).toBeOneOf(['A', 'B'])
-
-    expect(graph.transitions.filter((transition) => transition.from === 1).length).toBe(2)
-    expect(graph.transitions.filter((transition) => transition.from === 1)[0].to).toBeOneOf([2, 1])
-    expect(graph.transitions.filter((transition) => transition.from === 1)[0].read).toBeOneOf(['A', 'B'])
-    expect(graph.transitions.filter((transition) => transition.from === 1)[1].to).toBeOneOf([2, 1])
-    expect(graph.transitions.filter((transition) => transition.from === 1)[1].read).toBeOneOf(['A', 'B'])
-
-    expect(graph.transitions.filter((transition) => transition.from === 2).length).toBe(2)
-    expect(graph.transitions.filter((transition) => transition.from === 2)[0].to).toBe(4)
-    expect(graph.transitions.filter((transition) => transition.from === 2)[0].read).toBeOneOf(['A', 'B'])
-    expect(graph.transitions.filter((transition) => transition.from === 2)[1].to).toBe(4)
-    expect(graph.transitions.filter((transition) => transition.from === 2)[1].read).toBeOneOf(['A', 'B'])
-
-    expect(graph.transitions.filter((transition) => transition.from === 3).length).toBe(2)
-    expect(graph.transitions.filter((transition) => transition.from === 3)[0].to).toBe(5)
-    expect(graph.transitions.filter((transition) => transition.from === 3)[0].read).toBeOneOf(['A', 'B'])
-    expect(graph.transitions.filter((transition) => transition.from === 3)[1].to).toBe(5)
-    expect(graph.transitions.filter((transition) => transition.from === 3)[1].read).toBeOneOf(['A', 'B'])
-
-    expect(graph.transitions.filter((transition) => transition.from === 4).length).toBe(2)
-    expect(graph.transitions.filter((transition) => transition.from === 4)[0].to).toBe(4)
-    expect(graph.transitions.filter((transition) => transition.from === 4)[0].read).toBeOneOf(['A', 'B'])
-    expect(graph.transitions.filter((transition) => transition.from === 4)[1].to).toBe(4)
-    expect(graph.transitions.filter((transition) => transition.from === 4)[1].read).toBeOneOf(['A', 'B'])
-
-    expect(graph.transitions.filter((transition) => transition.from === 5).length).toBe(2)
-    expect(graph.transitions.filter((transition) => transition.from === 5)[0].to).toBe(5)
-    expect(graph.transitions.filter((transition) => transition.from === 5)[0].read).toBeOneOf(['A', 'B'])
-    expect(graph.transitions.filter((transition) => transition.from === 5)[1].to).toBe(5)
-    expect(graph.transitions.filter((transition) => transition.from === 5)[1].read).toBeOneOf(['A', 'B'])
+    expect(graph).toEqual(convertHarderConversionDFA)
   })
   test('Graph should use a single trap state instead of multiple when converted to a DFA', () => {
     const graph = convertToDFA(convertSingleTrapState as FSAProjectGraph)
-    // Initial state should be q0
-    expect(graph.initialState).toBe(0)
-    // Should be 4 states
-    expect(graph.states.length).toBe(4)
-    // Should be one final state, q3
-    for (let curState = 0; curState < graph.states.length; curState++) {
-      if (curState === 3) {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
-      } else {
-        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
-      }
-    }
-    // No lambda transition should be found, and should be 28 transitions total. All states should have a single transition 'A' to 'G' and be connected in a certain way
-    expect(graph.transitions.length).toBe(28)
-    const alphabet = 'ABCDEFG'
-    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
-    // Transitions that are not initially present should all go to a single trap state "2"
-    const isTrapped = (from: number, toTrap: string) => {
-      const transitions = graph.transitions.filter(t => t.from === from)
-      expect(transitions.length).toBe(alphabet.length)
-      // Find all the transitions that read a symbol we expect to go to a trap state
-      const expectedTrapTransitions = transitions
-        .filter(t => toTrap.includes(t.read))
-        .map(t => t.to)
-      expect(new Set(expectedTrapTransitions).size).toBe(1)
-      // All trap transitions should be going to state '2' (The trap state)
-      expect(expectedTrapTransitions[0]).toBe(2)
-    }
-    // Transitions that are not initially present should all go to a single trap state "2"
-    isTrapped(0, 'CDEFG')
-    isTrapped(1, 'AB')
-    // This is the trap state, should go to itself for every symbol
-    isTrapped(2, alphabet)
-    // Final state with no transitions to must all go to a single trap state
-    isTrapped(3, alphabet)
+    expect(graph).toEqual(convertSingleTrapStateDFA)
   })
 })

--- a/packages/simulation/tests/convertNFAtoDFA.test.ts
+++ b/packages/simulation/tests/convertNFAtoDFA.test.ts
@@ -52,7 +52,7 @@ describe('Check to ensure DFA graph is displayed as expected', () => {
     expect(graph).toEqual(convertSimpleConversionDFA)
   })
   test('Graph should be converted correctly to DFA when initial state is not at the start', () => {
-    const graph = reorderStates(convertNFAtoDFA(reorderStates(convertInitialNotAtStart as any) as any) as any)
+    const graph = convertToDFA(convertInitialNotAtStart as FSAProjectGraph)
     expect(graph).toEqual(convertInitialNotAtStartDFA)
   })
   test('Graph should be converted correctly to DFA with multiple final states', () => {

--- a/packages/simulation/tests/convertNFAtoDFA.test.ts
+++ b/packages/simulation/tests/convertNFAtoDFA.test.ts
@@ -49,13 +49,17 @@ describe('Check to ensure DFA graph is displayed as expected', () => {
     // They would be 3 if they got returned as a DFA rather than 4 as an NFA
     expect(graph.states.length).toBe(3)
     // Only q1 should be a final state
-    expect((graph.states.find((state) => state.id === 0)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 1)).isFinal).toBe(true)
-    expect((graph.states.find((state) => state.id === 2)).isFinal).toBe(false)
+    for (let curState = 0; curState < graph.states.length; curState++) {
+      if (curState === 1) {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
+      } else {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
+      }
+    }
     // No lambda transition should be found, and should be 3 transitions total. All transitions should have symbol "A"
     expect(graph.transitions.length).toBe(3)
-    expect(graph.transitions.some((transition) => transition.read === undefined)).toBe(false)
-    expect(graph.transitions.every((transition) => transition.read === 'A')).toBe(true)
+    const alphabet = 'A'
+    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
     // Transitions should go in a straight line except the trap state, which goes to itself
     expect(graph.transitions[0].from).toBe(0)
     expect(graph.transitions[0].to).toBe(1)
@@ -71,13 +75,17 @@ describe('Check to ensure DFA graph is displayed as expected', () => {
     // They would be 3 if they got returned as a DFA rather than 4 as an NFA
     expect(graph.states.length).toBe(3)
     // Only q1 should be a final state
-    expect((graph.states.find((state) => state.id === 0)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 1)).isFinal).toBe(true)
-    expect((graph.states.find((state) => state.id === 2)).isFinal).toBe(false)
+    for (let curState = 0; curState < graph.states.length; curState++) {
+      if (curState === 1) {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
+      } else {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
+      }
+    }
     // No lambda transition should be found, and should be 3 transitions total. All transitions should have symbol "A"
     expect(graph.transitions.length).toBe(3)
-    expect(graph.transitions.some((transition) => transition.read === undefined)).toBe(false)
-    expect(graph.transitions.every((transition) => transition.read === 'A')).toBe(true)
+    const alphabet = 'A'
+    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
     // Transitions should go in a straight line except the trap state, which goes to itself
     expect(graph.transitions[0].from).toBe(0)
     expect(graph.transitions[0].to).toBe(1)
@@ -92,14 +100,18 @@ describe('Check to ensure DFA graph is displayed as expected', () => {
     expect(graph.initialState).toBe(0)
     // They would be 3 if they got returned as a DFA rather than 4 as an NFA
     expect(graph.states.length).toBe(3)
-    // Only q1 should be a final state
-    expect((graph.states.find((state) => state.id === 0)).isFinal).toBe(true)
-    expect((graph.states.find((state) => state.id === 1)).isFinal).toBe(true)
-    expect((graph.states.find((state) => state.id === 2)).isFinal).toBe(false)
+    // Both q0 and q1 should be final states
+    for (let curState = 0; curState < graph.states.length; curState++) {
+      if (curState === 0 || curState === 1) {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
+      } else {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
+      }
+    }
     // No lambda transition should be found, and should be 3 transitions total. All transitions should have symbol "A"
     expect(graph.transitions.length).toBe(3)
-    expect(graph.transitions.some((transition) => transition.read === undefined)).toBe(false)
-    expect(graph.transitions.every((transition) => transition.read === 'A')).toBe(true)
+    const alphabet = 'A'
+    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
     // Transitions should go in a straight line except the trap state, which goes to itself
     expect(graph.transitions[0].from).toBe(0)
     expect(graph.transitions[0].to).toBe(1)
@@ -115,16 +127,17 @@ describe('Check to ensure DFA graph is displayed as expected', () => {
     // They would be 6 if they got returned as a DFA rather than 4 as an NFA
     expect(graph.states.length).toBe(6)
     // Should be two final states, q2 and q3
-    expect((graph.states.find((state) => state.id === 0)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 1)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 2)).isFinal).toBe(true)
-    expect((graph.states.find((state) => state.id === 3)).isFinal).toBe(true)
-    expect((graph.states.find((state) => state.id === 4)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 5)).isFinal).toBe(false)
+    for (let curState = 0; curState < graph.states.length; curState++) {
+      if (curState === 2 || curState === 3) {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
+      } else {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
+      }
+    }
     // No lambda transition should be found, and should be 12 transitions total. All states should have a single transition 'A' and 'B' from, and be connected in a certain way
     expect(graph.transitions.length).toBe(12)
-    expect(graph.transitions.some((transition) => transition.read === undefined)).toBe(false)
-    expect(graph.transitions.every((transition) => transition.read === 'A' || transition.read === 'B')).toBe(true)
+    const alphabet = 'AB'
+    expect(graph.transitions.every((transition) => alphabet.includes(transition.read))).toBe(true)
     // Transitions should be connected appropriately
     expect(graph.transitions.filter((transition) => transition.from === 0).length).toBe(2)
     expect(graph.transitions.filter((transition) => transition.from === 0)[0].to).toBeOneOf([1, 3])
@@ -169,10 +182,13 @@ describe('Check to ensure DFA graph is displayed as expected', () => {
     // Should be 4 states
     expect(graph.states.length).toBe(4)
     // Should be one final state, q3
-    expect((graph.states.find((state) => state.id === 0)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 1)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 2)).isFinal).toBe(false)
-    expect((graph.states.find((state) => state.id === 3)).isFinal).toBe(true)
+    for (let curState = 0; curState < graph.states.length; curState++) {
+      if (curState === 3) {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(true)
+      } else {
+        expect((graph.states.find((state) => state.id === curState)).isFinal).toBe(false)
+      }
+    }
     // No lambda transition should be found, and should be 28 transitions total. All states should have a single transition 'A' to 'G' and be connected in a certain way
     expect(graph.transitions.length).toBe(28)
     const alphabet = 'ABCDEFG'

--- a/packages/simulation/tests/graphs/convertHarderConversionDFA.json
+++ b/packages/simulation/tests/graphs/convertHarderConversionDFA.json
@@ -1,0 +1,137 @@
+{
+  "projectType": "FSA",
+  "states": [
+    {
+      "id": 0,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 1,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 2,
+      "isFinal": true,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 4,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 3,
+      "isFinal": true,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 5,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "id": 0,
+      "read": "B",
+      "to": 1
+    },
+    {
+      "from": 0,
+      "id": 1,
+      "read": "A",
+      "to": 3
+    },
+    {
+      "from": 1,
+      "id": 2,
+      "read": "A",
+      "to": 2
+    },
+    {
+      "from": 1,
+      "id": 3,
+      "read": "B",
+      "to": 1
+    },
+    {
+      "from": 2,
+      "id": 4,
+      "read": "A",
+      "to": 4
+    },
+    {
+      "from": 2,
+      "id": 5,
+      "read": "B",
+      "to": 4
+    },
+    {
+      "from": 4,
+      "id": 8,
+      "read": "A",
+      "to": 4
+    },
+    {
+      "from": 4,
+      "id": 9,
+      "read": "B",
+      "to": 4
+    },
+    {
+      "from": 3,
+      "id": 10,
+      "read": "A",
+      "to": 5
+    },
+    {
+      "from": 3,
+      "id": 11,
+      "read": "B",
+      "to": 5
+    },
+    {
+      "from": 5,
+      "id": 12,
+      "read": "A",
+      "to": 5
+    },
+    {
+      "from": 5,
+      "id": 13,
+      "read": "B",
+      "to": 5
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Thankful Caterpillar",
+    "dateCreated": 1682044927890,
+    "dateEdited": 1682044927890,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "FSA",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "orange"
+  }
+}

--- a/packages/simulation/tests/graphs/convertInitialNotAtStartDFA.json
+++ b/packages/simulation/tests/graphs/convertInitialNotAtStartDFA.json
@@ -1,0 +1,65 @@
+{
+  "projectType": "FSA",
+  "states": [
+    {
+      "id": 0,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 1,
+      "isFinal": true,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 2,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "id": 0,
+      "read": "A",
+      "to": 1
+    },
+    {
+      "from": 1,
+      "id": 1,
+      "read": "A",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 2,
+      "read": "A",
+      "to": 2
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Thankful Caterpillar",
+    "dateCreated": 1682044927890,
+    "dateEdited": 1682044927890,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "FSA",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "orange"
+  }
+}

--- a/packages/simulation/tests/graphs/convertMultipleFinalDFA.json
+++ b/packages/simulation/tests/graphs/convertMultipleFinalDFA.json
@@ -1,0 +1,65 @@
+{
+  "projectType": "FSA",
+  "states": [
+    {
+      "id": 0,
+      "isFinal": true,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 1,
+      "isFinal": true,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 2,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "id": 0,
+      "read": "A",
+      "to": 1
+    },
+    {
+      "from": 1,
+      "id": 4,
+      "read": "A",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 5,
+      "read": "A",
+      "to": 2
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Thankful Caterpillar",
+    "dateCreated": 1682044927890,
+    "dateEdited": 1682044927890,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "FSA",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "orange"
+  }
+}

--- a/packages/simulation/tests/graphs/convertSimpleConversionDFA.json
+++ b/packages/simulation/tests/graphs/convertSimpleConversionDFA.json
@@ -1,0 +1,65 @@
+{
+  "projectType": "FSA",
+  "states": [
+    {
+      "id": 0,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 1,
+      "isFinal": true,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 2,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "id": 0,
+      "read": "A",
+      "to": 1
+    },
+    {
+      "from": 1,
+      "id": 4,
+      "read": "A",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 5,
+      "read": "A",
+      "to": 2
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Thankful Caterpillar",
+    "dateCreated": 1682044927890,
+    "dateEdited": 1682044927890,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "FSA",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "orange"
+  }
+}

--- a/packages/simulation/tests/graphs/convertSingleTrapStateDFA.json
+++ b/packages/simulation/tests/graphs/convertSingleTrapStateDFA.json
@@ -1,0 +1,221 @@
+{
+  "projectType": "FSA",
+  "states": [
+    {
+      "id": 0,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 1,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 3,
+      "isFinal": true,
+      "x": 765,
+      "y": 330
+    },
+    {
+      "id": 2,
+      "isFinal": false,
+      "x": 765,
+      "y": 330
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "id": 0,
+      "read": "A",
+      "to": 1
+    },
+    {
+      "from": 0,
+      "id": 1,
+      "read": "B",
+      "to": 1
+    },
+    {
+      "from": 0,
+      "id": 2,
+      "read": "C",
+      "to": 2
+    },
+    {
+      "from": 0,
+      "id": 3,
+      "read": "D",
+      "to": 2
+    },
+    {
+      "from": 0,
+      "id": 4,
+      "read": "E",
+      "to": 2
+    },
+    {
+      "from": 0,
+      "id": 5,
+      "read": "F",
+      "to": 2
+    },
+    {
+      "from": 0,
+      "id": 6,
+      "read": "G",
+      "to": 2
+    },
+    {
+      "from": 1,
+      "id": 7,
+      "read": "C",
+      "to": 0
+    },
+    {
+      "from": 1,
+      "id": 8,
+      "read": "D",
+      "to": 0
+    },
+    {
+      "from": 1,
+      "id": 9,
+      "read": "E",
+      "to": 1
+    },
+    {
+      "from": 1,
+      "id": 10,
+      "read": "F",
+      "to": 1
+    },
+    {
+      "from": 1,
+      "id": 11,
+      "read": "G",
+      "to": 3
+    },
+    {
+      "from": 1,
+      "id": 12,
+      "read": "A",
+      "to": 2
+    },
+    {
+      "from": 1,
+      "id": 13,
+      "read": "B",
+      "to": 2
+    },
+    {
+      "from": 3,
+      "id": 14,
+      "read": "A",
+      "to": 2
+    },
+    {
+      "from": 3,
+      "id": 15,
+      "read": "B",
+      "to": 2
+    },
+    {
+      "from": 3,
+      "id": 16,
+      "read": "C",
+      "to": 2
+    },
+    {
+      "from": 3,
+      "id": 17,
+      "read": "D",
+      "to": 2
+    },
+    {
+      "from": 3,
+      "id": 18,
+      "read": "E",
+      "to": 2
+    },
+    {
+      "from": 3,
+      "id": 19,
+      "read": "F",
+      "to": 2
+    },
+    {
+      "from": 3,
+      "id": 20,
+      "read": "G",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 21,
+      "read": "A",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 22,
+      "read": "B",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 23,
+      "read": "C",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 24,
+      "read": "D",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 25,
+      "read": "E",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 26,
+      "read": "F",
+      "to": 2
+    },
+    {
+      "from": 2,
+      "id": 27,
+      "read": "G",
+      "to": 2
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Busy Grass",
+    "dateCreated": 1682132769959,
+    "dateEdited": 1682132769959,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "FSA",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "orange"
+  }
+}


### PR DESCRIPTION
A small PR that just cleans up the presentation of the convert tests, nothing to do with functionality. In terms of the behavior of the transitions, since the requirements for them to be correct are extremely specific for each test, I found it difficult to automise them and have left them alone as a result, however everything else has been cleaned up appropriately.