### PR TITLE
Fix projects not being exportable

### DIFF
--- a/frontend/src/hooks/useActions.js
+++ b/frontend/src/hooks/useActions.js
@@ -82,7 +82,7 @@ const useActions = (registerHotkeys = false) => {
       hotkey: { key: 's', shift: true, meta: true },
       handler: () => {
         // Pull project state
-        const project = useProjectStore.getState()
+        const project = useProjectStore.getState().project
 
         // Create a download link and use it
         const a = document.createElement('a')


### PR DESCRIPTION
Small bug that stopped exports. Issue was that it wasn't getting the actual value of the project