### PR TITLE
Fix not being able to move both states and comments

### DIFF
--- a/frontend/src/hooks/useCommentDragging.ts
+++ b/frontend/src/hooks/useCommentDragging.ts
@@ -1,12 +1,20 @@
 import { useProjectStore } from '/src/stores'
 
-import useResourceDragging from './useResourceDragging'
+import useResourceDragging, { ResourceDraggingHook } from './useResourceDragging'
+import { ProjectComment } from '/src/types/ProjectTypes'
 
-const commentsFromIDs = (IDs: number[]) => {
+/**
+ * Comment that doesn't have an optional ID (it is guaranteed to be set).
+ * Since the filter only allows set IDs we can safely know this
+ */
+type CommentWithID = Omit<ProjectComment, 'id'> & {id: number}
+
+const commentsFromIDs = (IDs: number[]): CommentWithID[] => {
   const comments = useProjectStore.getState()?.project?.comments ?? []
-  return comments.filter(comment => IDs.includes(comment.id))
+  return comments.filter(comment => IDs.includes(comment.id)) as CommentWithID[]
 }
 
 const makeUpdateComment = () => useProjectStore(s => s.updateComment)
 
-export default useResourceDragging.bind(null, commentsFromIDs, makeUpdateComment)
+// export default () => useResourceDragging(commentsFromIDs, makeUpdateComment)
+export default useResourceDragging.bind(null, commentsFromIDs, makeUpdateComment) as () => ResourceDraggingHook

--- a/frontend/src/hooks/useCommentDragging.ts
+++ b/frontend/src/hooks/useCommentDragging.ts
@@ -4,8 +4,7 @@ import useResourceDragging from './useResourceDragging'
 
 const commentsFromIDs = (IDs: number[]) => {
   const comments = useProjectStore.getState()?.project?.comments ?? []
-  return IDs
-    .map(id => comments.find(comment => comment.id === id))
+  return comments.filter(comment => IDs.includes(comment.id))
 }
 
 const makeUpdateComment = () => useProjectStore(s => s.updateComment)

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -30,6 +30,7 @@ export interface CustomEvents {
   'modal:shortcuts': null,
   'svg:mousedown': SVGMouseData,
   'svg:mouseup': SVGMouseData,
+  'svg:mousemove': SVGMouseData,
   'state:mouseup': SVGMouseData,
   'state:mousedown': SVGMouseData,
   'transition:mouseup': {originalEvent: MouseEvent, transition: PositionedTransition},

--- a/frontend/src/hooks/useResourceDragging.ts
+++ b/frontend/src/hooks/useResourceDragging.ts
@@ -4,7 +4,13 @@ import { useEvent } from '/src/hooks'
 import { useProjectStore, useToolStore, useViewStore, usePreferencesStore } from '/src/stores'
 import { GRID_SNAP } from '/src/config/interactions'
 
-const useResourceDragging = (resourcesFromIDs, makeUpdateResource) => {
+interface RequiredProps {
+  x: number
+  y: number
+  id: number
+}
+
+const useResourceDragging = <T extends RequiredProps>(resourcesFromIDs: (IDs: number[]) => T[], makeUpdateResource: () => (x: Partial<T>) => void) => {
   const tool = useToolStore(s => s.tool)
   const toolActive = tool === 'cursor'
 
@@ -12,9 +18,9 @@ const useResourceDragging = (resourcesFromIDs, makeUpdateResource) => {
   const commit = useProjectStore(s => s.commit)
   const screenToViewSpace = useViewStore(s => s.screenToViewSpace)
 
-  const [dragOffsets, setDragOffsets] = useState()
-  const [dragCenters, setDragCenters] = useState()
-  const [dragging, setDragging] = useState(null)
+  const [dragOffsets, setDragOffsets] = useState<[number, number][]>()
+  const [dragCenters, setDragCenters] = useState<[number, number][]>()
+  const [dragging, setDragging] = useState<number[]>(null)
 
   const gridVisible = usePreferencesStore(state => state.preferences.showGrid)
 
@@ -55,7 +61,7 @@ const useResourceDragging = (resourcesFromIDs, makeUpdateResource) => {
             : [(Math.floor(lx / GRID_SNAP) * GRID_SNAP) + lox, Math.floor(ly / GRID_SNAP) * GRID_SNAP + loy]
 
         // Update state position
-        updateResource({ id, x: sx, y: sy })
+        updateResource({ id, x: sx, y: sy } as Partial<T>)
       })
     }
   }, [toolActive, dragging, gridVisible])

--- a/frontend/src/hooks/useResourceDragging.ts
+++ b/frontend/src/hooks/useResourceDragging.ts
@@ -10,7 +10,17 @@ interface RequiredProps {
   id: number
 }
 
-const useResourceDragging = <T extends RequiredProps>(resourcesFromIDs: (IDs: number[]) => T[], makeUpdateResource: () => (x: Partial<T>) => void) => {
+type DragEvent = {detail: {originalEvent: MouseEvent}}
+export type ResourceDraggingHook = {startDrag: (e: DragEvent, ids: number[]) => void}
+
+/**
+ * Handles dragging of resources (e.g. comments, states)
+ * @param resourcesFromIDs Function takes a list of IDs and returns resources with those IDs
+ * @param makeUpdateResource Function that updates the resource in the store
+ */
+const useResourceDragging = <T extends RequiredProps>(
+  resourcesFromIDs: (IDs: number[]) => T[],
+  makeUpdateResource: () => (x: Partial<T>) => void): ResourceDraggingHook => {
   const tool = useToolStore(s => s.tool)
   const toolActive = tool === 'cursor'
 
@@ -24,7 +34,7 @@ const useResourceDragging = <T extends RequiredProps>(resourcesFromIDs: (IDs: nu
 
   const gridVisible = usePreferencesStore(state => state.preferences.showGrid)
 
-  const startDrag = useCallback((e, selectedResourceIDs) => {
+  const startDrag = useCallback((e: DragEvent, selectedResourceIDs: number[]) => {
     if (toolActive) {
       const [x, y] = screenToViewSpace(e.detail.originalEvent.clientX, e.detail.originalEvent.clientY)
       const selected = resourcesFromIDs(selectedResourceIDs)

--- a/frontend/src/hooks/useResourceSelection.tsx
+++ b/frontend/src/hooks/useResourceSelection.tsx
@@ -2,7 +2,7 @@ import { useCallback } from 'react'
 
 import { useSelectionStore, useToolStore } from '/src/stores'
 
-type SelectionEvent = CustomEvent<{originalEvent: MouseEvent, ids?: number[]}>
+export type SelectionEvent = CustomEvent<{originalEvent: MouseEvent, ids?: number[]}>
 
 const useResourceSelection = (getSelected: () => number[], makeSetter: () => (x: number[]) => void, eventKey: string) => {
   const tool = useToolStore(s => s.tool)

--- a/frontend/src/hooks/useStateDragging.ts
+++ b/frontend/src/hooks/useStateDragging.ts
@@ -1,12 +1,12 @@
 import { useProjectStore } from '/src/stores'
 
 import useResourceDragging from './useResourceDragging'
+import { AutomataState } from '/src/types/ProjectTypes'
 
 // Setup state interactivity deps
-const statesFromIDs = IDs => {
+const statesFromIDs = (IDs: number[]): AutomataState[] => {
   const states = useProjectStore.getState()?.project?.states ?? []
-  return IDs
-    .map(id => states.find(state => state.id === id))
+  return states.filter(state => IDs.includes(state.id))
 }
 const makeUpdateState = () => useProjectStore(s => s.updateState)
 

--- a/frontend/src/hooks/useStateDragging.ts
+++ b/frontend/src/hooks/useStateDragging.ts
@@ -1,6 +1,6 @@
 import { useProjectStore } from '/src/stores'
 
-import useResourceDragging from './useResourceDragging'
+import useResourceDragging, { ResourceDraggingHook } from './useResourceDragging'
 import { AutomataState } from '/src/types/ProjectTypes'
 
 // Setup state interactivity deps
@@ -10,4 +10,4 @@ const statesFromIDs = (IDs: number[]): AutomataState[] => {
 }
 const makeUpdateState = () => useProjectStore(s => s.updateState)
 
-export default useResourceDragging.bind(null, statesFromIDs, makeUpdateState)
+export default useResourceDragging.bind(null, statesFromIDs, makeUpdateState) as () => ResourceDraggingHook


### PR DESCRIPTION
Closes #214 

The issue was that the dragging for comments and states was handled separately and so you could only drag one or the other.

This also does conversion to typescript for the dragging related files