### PR TITLE
Check if we need to save, even if not logged in

### DIFF
--- a/frontend/src/components/Menubar/Menubar.tsx
+++ b/frontend/src/components/Menubar/Menubar.tsx
@@ -78,7 +78,7 @@ const Menubar = () => {
   const lastSaveDate = useProjectStore(s => s.lastSaveDate)
   const lastChangeDate = useProjectStore(s => s.lastChangeDate)
   // Determine whether saving
-  const isSaving = useMemo(() => user && !(!lastChangeDate || dayjs(lastSaveDate).isAfter(lastChangeDate)), [user, lastChangeDate, lastSaveDate])
+  const isSaving = useMemo(() => !(!lastChangeDate || dayjs(lastSaveDate).isAfter(lastChangeDate)), [lastChangeDate, lastSaveDate])
 
   const handleEditProjectName = () => {
     setTitleValue(projectName ?? '')
@@ -136,7 +136,7 @@ const Menubar = () => {
                 : (
                 <Name onClick={handleEditProjectName} title="Edit title">{projectName ?? 'Untitled Project'}</Name>
                   )}
-              <SaveStatus $show={isSaving}>Saving...</SaveStatus>
+              <SaveStatus $show={isSaving && !!user}>Saving...</SaveStatus>
             </NameRow>
 
             <DropdownMenus>


### PR DESCRIPTION
Closes #318 

Problem was that the frontend only considered that it was trying to save if the user was signed in and there was a modification. This makes it only check modification time and ignore the user.

The check for user was moved into the saving icon since we don't want to show it if only showing locally and not syncing to a backend