### PR TITLE
Fix not being able to drag items

### DIFF
--- a/frontend/src/components/CommentRect/CommentRect.tsx
+++ b/frontend/src/components/CommentRect/CommentRect.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, MouseEvent } from 'react'
 
 import { dispatchCustomEvent } from '/src/util/events'
 import { useSelectionStore, useViewStore } from '/src/stores'
 
 import { commentStyles, commentSelectedClass } from './commentRectStyle'
+import { CustomEvents } from '/src/hooks/useEvent'
 
 interface CommentRectProps {
   id: number
@@ -29,13 +30,8 @@ const CommentRect = ({ id, x, y, text }: CommentRectProps) => {
     }
   }, [containerRef?.current, text, x, y])
 
-  const handleMouseDown = e =>
-    dispatchCustomEvent('comment:mousedown', {
-      originalEvent: e,
-      comment: { id, text }
-    })
-  const handleMouseUp = e =>
-    dispatchCustomEvent('comment:mouseup', {
+  const dispatchMouseEvent = (name: keyof CustomEvents) => (e: MouseEvent) =>
+    dispatchCustomEvent(name, {
       originalEvent: e,
       comment: { id, text }
     })
@@ -43,8 +39,9 @@ const CommentRect = ({ id, x, y, text }: CommentRectProps) => {
   return <foreignObject x={x} y={y} {...size}>
     <div
       ref={containerRef}
-      onMouseDown={handleMouseDown}
-      onMouseUp={handleMouseUp}
+      onMouseDown={dispatchMouseEvent('comment:mousedown')}
+      onMouseUp={dispatchMouseEvent('comment:mouseup')}
+      onDoubleClick={dispatchMouseEvent('comment:dblclick')}
       style={commentStyles}
       className={(selected && commentSelectedClass) || undefined}
     >{text}</div>

--- a/frontend/src/components/StateCircle/StateCircle.tsx
+++ b/frontend/src/components/StateCircle/StateCircle.tsx
@@ -1,10 +1,11 @@
-import { useRef, useEffect, useState } from 'react'
+import { useRef, useEffect, useState, MouseEvent } from 'react'
 
 import { dispatchCustomEvent } from '/src/util/events'
 import { useProjectStore } from '/src/stores'
 import { STATE_CIRCLE_RADIUS } from '/src/config/rendering'
 
 import { circleStyles, stepGlowStyle, circleSelectedClass, textStyles } from './stateCircleStyle'
+import { CustomEvents } from '/src/hooks/useEvent'
 
 const FINAL_OUTLINE_OFFSET = 5
 
@@ -13,8 +14,8 @@ const StateCircle = ({ id, name, label, isFinal, cx, cy, selected, stepped, ...p
 
   const displayName = name || `${statePrefix}${id}`
 
-  const labelRef = useRef()
-  const [labelBox, setLabelBox] = useState()
+  const labelRef = useRef<SVGTextElement>()
+  const [labelBox, setLabelBox] = useState<{x: number, y: number, width: number, height: number}>()
 
   useEffect(() => {
     const { x, y, width, height } = labelRef.current?.getBBox() ?? {}
@@ -22,18 +23,18 @@ const StateCircle = ({ id, name, label, isFinal, cx, cy, selected, stepped, ...p
   }, [labelRef.current, label])
 
   // TODO: use Callback
-  const handleStateMouseUp = e =>
-    dispatchCustomEvent('state:mouseup', {
+  const handleEvent = (eventName: keyof CustomEvents) => (e: MouseEvent) => {
+    dispatchCustomEvent(eventName, {
       originalEvent: e,
       state: { id, name, cx, cy }
     })
-  const handleStateMouseDown = e =>
-    dispatchCustomEvent('state:mousedown', {
-      originalEvent: e,
-      state: { id, name, cx, cy }
-    })
+  }
 
-  return <g transform={`translate(${cx}, ${cy})`} onMouseDown={handleStateMouseDown} onMouseUp={handleStateMouseUp} {...props}>
+  return <g transform={`translate(${cx}, ${cy})`}
+            onMouseDown={handleEvent('state:mousedown')}
+            onMouseUp={handleEvent('state:mouseup')}
+            onDoubleClick={handleEvent('state:dblclick')}
+            {...props}>
     {/* Filled Circle */}
     <circle r={STATE_CIRCLE_RADIUS} style={{ ...circleStyles, ...(stepped ? stepGlowStyle : {}) }} className={(selected && circleSelectedClass) || undefined} />
 

--- a/frontend/src/components/StateCircle/stateCircleStyle.ts
+++ b/frontend/src/components/StateCircle/stateCircleStyle.ts
@@ -18,4 +18,4 @@ export const circleSelectedClass = css`
 export const textStyles = {
   userSelect: 'none',
   fill: 'var(--stroke)'
-}
+} as const

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react'
+import { MouseEvent, useContext } from 'react'
 import { useProjectStore } from '../../stores'
 import { MarkerContext } from '/src/providers'
 import { STATE_CIRCLE_RADIUS, TRANSITION_SEPERATION, REFLEXIVE_Y_OFFSET, REFLEXIVE_X_OFFSET } from '/src/config/rendering'
@@ -157,13 +157,20 @@ const Transition = ({
       originalEvent: e,
       transition: t
     })
-  const handleTransitionDoubleClick = (t: PositionedTransition) => () =>
+  const handleTransitionDoubleClick = (t: PositionedTransition) => (e: MouseEvent) => {
     dispatchCustomEvent('editTransition', { id: t.id })
+    // Needs to be a different event since this takes the whole transition object but editTransition only supports IDs
+    // The need for the whole object is so that it is inline with the other events
+    dispatchCustomEvent('transition:dblclick', { originalEvent: e, transition: t })
+  }
 
   // Callbacks for the edge
 
   const handleEdgeMouseDown = e =>
     dispatchCustomEvent('edge:mousedown', { originalEvent: e, transitions })
+
+  const handleEdgeDoubleClick = e =>
+    dispatchCustomEvent('edge:dblclick', { originalEvent: e, transitions })
 
   // Calculate text offset. We want transitions that curve under to extend downwards and over/straight to extend
   // upwards.
@@ -196,6 +203,7 @@ const Transition = ({
       stroke='transparent'
       fill='none'
       onMouseDown={handleEdgeMouseDown}
+      onDoubleClick={handleEdgeDoubleClick}
       strokeWidth={20}
     />}
 

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, DependencyList } from 'react'
+import { useEffect, useCallback, DependencyList, MouseEvent } from 'react'
 import { SidePanelKey } from '/src/components/Sidepanel/Panels'
 import { PositionedTransition } from '/src/util/states'
 
@@ -9,8 +9,15 @@ import { Coordinate } from '/src/types/ProjectTypes'
  * and if it was clicking the SVG
  */
 type SVGMouseData = {originalEvent: MouseEvent, didTargetSVG: boolean, viewX: number, viewY: number}
-type CommentEventData = {originalEvent: MouseEvent, comment: {id: number, text: string}}
 
+export type StateEventData = {originalEvent: MouseEvent, state: {id: number, name: string, cx: number, cy: number}}
+
+export type CommentEventData = {originalEvent: MouseEvent, comment: {id: number, text: string}}
+/**
+ * Contains information about the click along with the transition that was clicked
+ */
+export type TransitionEventData = {originalEvent: MouseEvent, transition: PositionedTransition}
+type EdgeEventData = {originalEvent: MouseEvent, transitions: PositionedTransition[]}
 /**
  * Mapping of events to what data the event accepts.
  * If making a custom event just add it here first
@@ -31,10 +38,12 @@ export interface CustomEvents {
   'svg:mousedown': SVGMouseData,
   'svg:mouseup': SVGMouseData,
   'svg:mousemove': SVGMouseData,
-  'state:mouseup': SVGMouseData,
-  'state:mousedown': SVGMouseData,
-  'transition:mouseup': {originalEvent: MouseEvent, transition: PositionedTransition},
-  'transition:mousedown': {originalEvent: MouseEvent, transition: PositionedTransition},
+  'state:mouseup': StateEventData,
+  'state:mousedown': StateEventData,
+  'state:dblclick': StateEventData
+  'transition:mouseup': TransitionEventData,
+  'transition:mousedown': TransitionEventData,
+  'transition:dblclick': TransitionEventData,
   'ctx:svg': Coordinate,
   'ctx:state': Coordinate,
   'ctx:transition': Coordinate,
@@ -43,11 +52,13 @@ export interface CustomEvents {
   'bottomPanel:close': null,
   'comment:mousedown': CommentEventData,
   'comment:mouseup': CommentEventData,
+  'comment:dblclick': CommentEventData,
   /**
    * Called when an edge (The line joining two states) is called. It contains
    * all the transitions that use that edge
    */
-  'edge:mousedown': {originalEvent: MouseEvent, transitions: PositionedTransition[]}
+  'edge:mousedown': EdgeEventData,
+  'edge:dblclick': EdgeEventData
 }
 
 /**

--- a/frontend/src/hooks/useResourceDragging.ts
+++ b/frontend/src/hooks/useResourceDragging.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, MouseEvent } from 'react'
 
 import { useEvent } from '/src/hooks'
 import { useProjectStore, useToolStore, useViewStore, usePreferencesStore } from '/src/stores'

--- a/frontend/src/hooks/useResourceSelection.ts
+++ b/frontend/src/hooks/useResourceSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { MouseEvent, useCallback } from 'react'
 
 import { useSelectionStore, useToolStore } from '/src/stores'
 
@@ -25,9 +25,13 @@ const useResourceSelection = (getSelected: () => number[], makeSetter: () => (x:
       } else if (usedShift) {
         // If shifting on a new resource, add it to the selected list
         newSelected = [...selected, ...ids]
+      } else if (alreadySelected) {
+        // If already selected then keep selected items.
+        // This keeps the items selecting while dragging
+        newSelected = selected
       } else {
-        // If nothing else, just keep the new items selected
-        newSelected = [...ids]
+        // Else just use what is selected
+        newSelected = ids
       }
       // Reset selected states?
       if (!alreadySelected && !e.detail.originalEvent.shiftKey) {


### PR DESCRIPTION
Issue was caused by the change to allow selecting a single item from a group selection.
This behavior is now changed to be a double click instead (i.e. if you select a whole group of states but then only want to select one, you double click it)