### PR TITLE
Fix the shortcuts page

### DIFF
--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -15,24 +15,24 @@ import { FSAProjectGraph } from '/src/types/ProjectTypes'
 /**
  * Combination of keys. Used to call an action
  */
-type HotKey = {key: string, meta?: boolean, shift?: boolean, alt?: boolean}
+export type HotKey = {key: string, meta?: boolean, shift?: boolean, alt?: boolean}
 
 /**
  * Represents an action handler
  */
 interface Handler {
   handler: (e?: KeyboardEvent | MouseEvent) => void
-  hotkey?: HotKey | HotKey[]
+  hotkeys?: HotKey[]
   disabled?: () => boolean
 }
 
 const isWindows = /Win/.test(navigator.platform)
-export const formatHotkey = (hotkey: HotKey) => [
+export const formatHotkey = (hotkey: HotKey): string => [
   hotkey.meta && (isWindows ? (isWindows ? 'Ctrl' : '⌃') : '⌘'),
   hotkey.alt && (isWindows ? 'Alt' : '⌥'),
   hotkey.shift && (isWindows ? 'Shift' : '⇧'),
   hotkey.key?.toUpperCase()
-].filter(Boolean)
+].filter(Boolean).join(isWindows ? '+' : ' ')
 
 const useActions = (registerHotkeys = false) => {
   const undo = useProjectStore(s => s.undo)
@@ -73,19 +73,19 @@ const useActions = (registerHotkeys = false) => {
       handler: () => navigate('/new')
     },
     IMPORT_AUTOMATARIUM_PROJECT: {
-      hotkey: { key: 'i', meta: true },
+      hotkeys: [{ key: 'i', meta: true }],
       handler: async () => {
         if (window.confirm('Importing will override your current project. Continue anyway?')) { promptLoadFile(JSON.parse, setProject, 'Failed to open automatarium project') }
       }
     },
     IMPORT_JFLAP_PROJECT: {
-      hotkey: { key: 'i', meta: true, shift: true },
+      hotkeys: [{ key: 'i', meta: true, shift: true }],
       handler: async () => {
         if (window.confirm('Importing will override your current project. Continue anyway?')) { promptLoadFile(convertJFLAPXML, setProject, 'Failed to open JFLAP project') }
       }
     },
     SAVE_FILE: {
-      hotkey: { key: 's', meta: true },
+      hotkeys: [{ key: 's', meta: true }],
       handler: () => {
         const project = useProjectStore.getState().project
         const toSave = { ...project, meta: { ...project.meta, dateEdited: new Date().getTime() } }
@@ -94,7 +94,7 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     SAVE_FILE_AS: {
-      hotkey: { key: 's', shift: true, meta: true },
+      hotkeys: [{ key: 's', shift: true, meta: true }],
       handler: () => {
         // Pull project state
         const project = useProjectStore.getState().project
@@ -109,19 +109,19 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     EXPORT: {
-      hotkey: { key: 'e', meta: true },
+      hotkeys: [{ key: 'e', meta: true }],
       handler: () => dispatchCustomEvent('exportImage', null)
     },
     EXPORT_AS_PNG: {
-      hotkey: { key: 'e', shift: true, meta: true },
+      hotkeys: [{ key: 'e', shift: true, meta: true }],
       handler: () => dispatchCustomEvent('exportImage', { type: 'png' })
     },
     EXPORT_AS_SVG: {
-      hotkey: { key: 'e', shift: true, alt: true, meta: true },
+      hotkeys: [{ key: 'e', shift: true, alt: true, meta: true }],
       handler: () => dispatchCustomEvent('exportImage', { type: 'svg' })
     },
     EXPORT_TO_CLIPBOARD: {
-      hotkey: { key: 'c', shift: true, meta: true },
+      hotkeys: [{ key: 'c', shift: true, meta: true }],
       handler: () => dispatchCustomEvent('exportImage', { type: 'png', clipboard: true })
     },
     EXPORT_AS_JFLAP: {
@@ -129,19 +129,19 @@ const useActions = (registerHotkeys = false) => {
       handler: () => console.log('Export JFLAP')
     },
     OPEN_PREFERENCES: {
-      hotkey: { key: ',', meta: true },
+      hotkeys: [{ key: ',', meta: true }],
       handler: () => dispatchCustomEvent('modal:preferences', null)
     },
     UNDO: {
-      hotkey: { key: 'z', meta: true },
+      hotkeys: [{ key: 'z', meta: true }],
       handler: undo
     },
     REDO: {
-      hotkey: { key: 'y', meta: true },
+      hotkeys: [{ key: 'y', meta: true }],
       handler: redo
     },
     COPY: {
-      hotkey: { key: 'c', meta: true },
+      hotkeys: [{ key: 'c', meta: true }],
       handler: () => {
         const selectedStates = selectedStatesIds.map((stateId) => {
           return project.states.find((state) => {
@@ -172,7 +172,7 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     PASTE: {
-      hotkey: { key: 'v', meta: true },
+      hotkeys: [{ key: 'v', meta: true }],
       handler: () => {
         const pasteData = JSON.parse(localStorage.getItem(COPY_DATA_KEY))
         if (pasteData === null) {
@@ -242,11 +242,11 @@ const useActions = (registerHotkeys = false) => {
 
     },
     SELECT_ALL: {
-      hotkey: { key: 'a', meta: true },
+      hotkeys: [{ key: 'a', meta: true }],
       handler: selectAll
     },
     DELETE: {
-      hotkey: [{ key: 'Delete' }, { key: 'Backspace' }],
+      hotkeys: [{ key: 'Delete' }, { key: 'Backspace' }],
       handler: () => {
         const selectionState = useSelectionStore.getState()
         const selectedStateIDs = selectionState.selectedStates
@@ -262,19 +262,19 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     ZOOM_IN: {
-      hotkey: { key: '=', meta: true },
+      hotkeys: [{ key: '=', meta: true }],
       handler: () => zoomViewTo(useViewStore.getState().scale - 0.1)
     },
     ZOOM_OUT: {
-      hotkey: { key: '-', meta: true },
+      hotkeys: [{ key: '-', meta: true }],
       handler: () => zoomViewTo(useViewStore.getState().scale + 0.1)
     },
     ZOOM_100: {
-      hotkey: { key: '0', meta: true },
+      hotkeys: [{ key: '0', meta: true }],
       handler: () => { zoomViewTo(1) }
     },
     ZOOM_FIT: {
-      hotkey: { key: 'f', shift: true },
+      hotkeys: [{ key: 'f', shift: true }],
       handler: () => {
         // Get state
         const view = useViewStore.getState()
@@ -303,15 +303,15 @@ const useActions = (registerHotkeys = false) => {
         : document.documentElement.requestFullscreen()
     },
     TESTING_LAB: {
-      hotkey: { key: '1', shift: true },
+      hotkeys: [{ key: '1', shift: true }],
       handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'test' })
     },
     FILE_INFO: {
-      hotkey: { key: '2', shift: true },
+      hotkeys: [{ key: '2', shift: true }],
       handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'about' })
     },
     FILE_OPTIONS: {
-      hotkey: { key: '3', shift: true },
+      hotkeys: [{ key: '3', shift: true }],
       handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'options' })
     },
     CONVERT_TO_DFA: {
@@ -337,7 +337,7 @@ const useActions = (registerHotkeys = false) => {
       handler: () => window.open('https://github.com/automatarium/automatarium/wiki', '_blank')
     },
     KEYBOARD_SHORTCUTS: {
-      hotkey: { key: '/', meta: true },
+      hotkeys: [{ key: '/', meta: true }],
       handler: () => dispatchCustomEvent('modal:shortcuts', null)
     },
     PRIVACY_POLICY: {
@@ -347,19 +347,19 @@ const useActions = (registerHotkeys = false) => {
       handler: () => window.open('/about', '_blank')
     },
     MOVE_VIEW_LEFT: {
-      hotkey: { key: 'ArrowLeft' },
+      hotkeys: [{ key: 'ArrowLeft' }],
       handler: () => moveView({ x: -VIEW_MOVE_STEP })
     },
     MOVE_VIEW_RIGHT: {
-      hotkey: { key: 'ArrowRight' },
+      hotkeys: [{ key: 'ArrowRight' }],
       handler: () => moveView({ x: VIEW_MOVE_STEP })
     },
     MOVE_VIEW_UP: {
-      hotkey: { key: 'ArrowUp' },
+      hotkeys: [{ key: 'ArrowUp' }],
       handler: () => moveView({ y: -VIEW_MOVE_STEP })
     },
     MOVE_VIEW_DOWN: {
-      hotkey: { key: 'ArrowDown' },
+      hotkeys: [{ key: 'ArrowDown' }],
       handler: () => moveView({ y: VIEW_MOVE_STEP })
     },
     SET_STATE_INITIAL: {
@@ -456,27 +456,27 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     TOOL_CURSOR: {
-      hotkey: { key: 'V' },
+      hotkeys: [{ key: 'V' }],
       handler: () => setTool('cursor')
     },
     TOOL_HAND: {
-      hotkey: { key: 'H' },
+      hotkeys: [{ key: 'H' }],
       handler: () => setTool('hand')
     },
     TOOL_STATE: {
-      hotkey: { key: 'S' },
+      hotkeys: [{ key: 'S' }],
       handler: () => setTool('state')
     },
     TOOL_TRANSITION: {
-      hotkey: { key: 'T' },
+      hotkeys: [{ key: 'T' }],
       handler: () => setTool('transition')
     },
     TOOL_COMMENT: {
-      hotkey: { key: 'C' },
+      hotkeys: [{ key: 'C' }],
       handler: () => setTool('comment')
     },
     TOOL_DELETE: {
-      hotkey: { key: 'D' },
+      hotkeys: [{ key: 'D' }],
       handler: () => {
         setTool('delete')
       }
@@ -500,12 +500,12 @@ const useActions = (registerHotkeys = false) => {
 
         for (const action of Object.values(actions)) {
           // Skip if no hotkey
-          if (!action.hotkey) { continue }
+          if (!action.hotkeys) { continue }
 
           // Skip if disabled
           if (action.disabled && action.disabled()) { continue }
 
-          const hotkeys = Array.isArray(action.hotkey) ? action.hotkey : [action.hotkey]
+          const hotkeys = action.hotkeys
           const activeHotkey = hotkeys.find(hotkey => {
             // Guard against other keys
             const letterMatch = e.code === `Key${hotkey.key.toUpperCase()}`
@@ -539,7 +539,7 @@ const useActions = (registerHotkeys = false) => {
   // Add formatted hotkeys to actions
   return useMemo(() => Object.fromEntries(Object.entries(actions).map(([key, action]) => ([key, {
     ...action,
-    label: action.hotkey ? formatHotkey(Array.isArray(action.hotkey) ? action.hotkey[0] : action.hotkey).join(isWindows ? '+' : ' ') : null
+    label: action.hotkeys ? formatHotkey(action.hotkeys[0]) : null
   }]))), [actions])
 }
 

--- a/frontend/src/pages/ShortcutGuide/ShortcutGuide.tsx
+++ b/frontend/src/pages/ShortcutGuide/ShortcutGuide.tsx
@@ -2,11 +2,26 @@ import { useMemo, Fragment, useState } from 'react'
 
 import { SectionLabel, Modal } from '/src/components'
 import { useActions, useEvent } from '/src/hooks'
-import { formatHotkey } from '/src/hooks/useActions'
+import { formatHotkey, HotKey } from '/src/hooks/useActions'
 
 import { Section, Shortcut } from './shortcutGuideStyle'
 
-const shortcuts = [
+interface ActionShortcut {
+  label: string
+  action: string
+}
+
+interface HotkeyShortcut {
+  label: string
+  hotkeys: HotKey[]
+}
+
+interface Category {
+  title: string
+  items: (ActionShortcut | HotkeyShortcut)[]
+}
+
+const shortcuts: Category[] = [
   {
     title: 'Application',
     items: [
@@ -111,11 +126,11 @@ const shortcuts = [
       },
       {
         label: 'Select multiple',
-        hotkeys: formatHotkey({ shift: true, key: '' })
+        hotkeys: [{ shift: true, key: '' }]
       },
       {
         label: 'Delete',
-        hotkeys: ['⌫']
+        hotkeys: [{ key: '⌫' }]
       }
     ]
   },
@@ -140,7 +155,7 @@ const shortcuts = [
       },
       {
         label: 'Fullscreen',
-        hotkeys: ['F11']
+        hotkeys: [{ key: 'F11' }]
       },
       {
         label: 'Testing lab',
@@ -156,11 +171,11 @@ const shortcuts = [
       },
       {
         label: 'Move view',
-        hotkeys: ['←', '↑', '→', '↓']
+        hotkeys: [{ key: '←' }, { key: '↑' }, { key: '→' }, { key: '↓' }]
       },
       {
         label: 'Drag without snapping',
-        hotkeys: formatHotkey({ alt: true, key: '' })
+        hotkeys: [{ alt: true, key: '' }]
       }
     ]
   },
@@ -169,28 +184,27 @@ const shortcuts = [
     items: [
       {
         label: 'Move between multi-run cells',
-        hotkeys: ['↑', '↓']
+        hotkeys: [{ key: '↑' }, { key: '↓' }]
       },
       {
         label: 'Create multi-run cell',
-        hotkeys: ['Enter']
+        hotkeys: [{ key: 'Enter' }]
       },
       {
         label: 'Delete multi-run cell',
-        hotkeys: ['⌫']
+        hotkeys: [{ key: '⌫' }]
       },
       {
         label: 'Execute multi-run',
-        hotkeys: formatHotkey({ meta: true, key: 'Enter' })
+        hotkeys: [{ meta: true, key: 'Enter' }]
       }
     ]
   }
-] as const
+]
 
 const ShortcutGuide = () => {
   const [isOpen, setIsOpen] = useState(false)
   useEvent('modal:shortcuts', () => setIsOpen(true), [])
-  if (!isOpen) return null
 
   const actions = useActions()
 
@@ -207,7 +221,10 @@ const ShortcutGuide = () => {
         <Section>{category.items.map(item => (
           <Shortcut key={item.label}>
             <label>{item.label}</label>
-            {((item.action && actions[item.action].hotkey) || item.hotkeys)?.map(key => <kbd key={key}>{key}</kbd>)}
+            {(('action' in item && actions[item.action]?.hotkeys) || (item as HotkeyShortcut).hotkeys)?.map(hotkey => {
+              const key = formatHotkey(hotkey)
+              return <kbd key={key}>{key}</kbd>
+            })}
           </Shortcut>
         ))}</Section>
       </Fragment>), [actions])}


### PR DESCRIPTION
Fixes out of order hook calls and a weird access to make the shortcuts page (Hotkey: `ctrl + /`) work again.

Also makes all the hotkeys be arrays instead of some being `HotKey` and some being `HotKey[]` so that access is easier