### PR TITLE
Only accept `.jff` and `.json` files in file importer

### DIFF
--- a/frontend/src/pages/NewFile/NewFile.tsx
+++ b/frontend/src/pages/NewFile/NewFile.tsx
@@ -60,6 +60,7 @@ const NewFile = () => {
     // Prompt user for file input
     const input = document.createElement('input')
     input.type = 'file'
+    input.accept = '.jff,.json'
     input.onchange = () => {
       // Read file data
       const reader = new FileReader()


### PR DESCRIPTION
Noticed in #373 that the file importer allows for any files which means the user has higher chance of clicking the wrong file and that every file is shown instead of the ones that the user is interested in.

This restricts the file input to only accept `.jff` and `.json` files (this is case insensitive, so `.JFF` is also accepted)

I'm leaving the file extension check in since the user can still override the browser and select anything