### PR TITLE
Fix regression for right clicking a state

### DIFF
--- a/frontend/src/components/EditorPanel/EditorPanel.tsx
+++ b/frontend/src/components/EditorPanel/EditorPanel.tsx
@@ -37,12 +37,12 @@ const EditorPanel = () => {
   useContextMenus()
 
   const handleDragging = (e: SelectionEvent) => {
+    // Only try and check if the user is selecting a new resource if the event correlates with that.
+    // Else just use the previous value from the store.
+    // Outside the if so that you can directly right-click and edit a state
+    const selStates = e.type === 'state:mousedown' ? selectState(e) : selectedStates
+    const selComments = e.type === 'comment:mousedown' ? selectComment(e) : selectedComments
     if (e.detail.originalEvent.button === 0) {
-      // Only try and check if the user is selecting a new resource if the event correlates with that.
-      // Else just use the previous value from the store
-      const selStates = e.type === 'state:mousedown' ? selectState(e) : selectedStates
-      const selComments = e.type === 'comment:mousedown' ? selectComment(e) : selectedComments
-
       startStateDrag(e, selStates)
       startCommentDrag(e, selComments)
     }

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -374,7 +374,7 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     TOGGLE_STATES_FINAL: {
-      disabled: () => useSelectionStore.getState()?.selectedStates?.length !== 1,
+      disabled: () => useSelectionStore.getState()?.selectedStates?.length === 0,
       handler: () => {
         const selectedStateIDs = useSelectionStore.getState().selectedStates
         if (selectedStateIDs.length > 0) {

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -374,6 +374,7 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     TOGGLE_STATES_FINAL: {
+      disabled: () => useSelectionStore.getState()?.selectedStates?.length !== 1,
       handler: () => {
         const selectedStateIDs = useSelectionStore.getState().selectedStates
         if (selectedStateIDs.length > 0) {


### PR DESCRIPTION
Closes #375 

Fix issue I caused in #370 that stopped right clicking from selecting. I had a mental note to move the code outside the if statement but kept forgetting to :stuck_out_tongue_closed_eyes:

I also made final state selection be disabled like initial state. This doesn't really change anything, but just makes it clearer that something needs to be selected