### PR TITLE
Remove the warnings from the console

### DIFF
--- a/frontend/src/components/Logo/Logo.tsx
+++ b/frontend/src/components/Logo/Logo.tsx
@@ -18,7 +18,10 @@ const Logo = ({
 }: LogoProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"
-    width={size} height={size}
+    style={{
+      width: size,
+      height: size
+    }}
     {...props}
   >
     {!hidePlanet && <circle fill={secondary} cx="241.33" cy="241.33" r="173.99"/>}

--- a/frontend/src/components/ProjectCard/ProjectCard.js
+++ b/frontend/src/components/ProjectCard/ProjectCard.js
@@ -17,7 +17,7 @@ const ProjectCard = ({ name, type, date, image, projectId, ...props }) => {
   const deleteProjectFromStore = useProjectsStore(s => s.deleteProject)
   return <CardContainer {...props}>
     <CardImage $image={!!image}>
-      {image ? <img src={image} alt="" /> : <Logo />}
+      {image ? <img src={image} alt="" /> : <Logo size={''} />}
       <TypeBadge>{type}</TypeBadge>
     </CardImage>
     <CardDetail>

--- a/frontend/src/components/Spinner/Spinner.tsx
+++ b/frontend/src/components/Spinner/Spinner.tsx
@@ -3,8 +3,8 @@ import { Logo } from '/src/components'
 import { SpinnerContainer } from './spinnerStyle'
 
 const Spinner = () => <SpinnerContainer>
-  <Logo hideTriangle />
-  <Logo hidePlanet />
+  <Logo hideTriangle size={''}/>
+  <Logo hidePlanet size={''}/>
 </SpinnerContainer>
 
 export default Spinner

--- a/frontend/src/pages/NewFile/images/PDA.tsx
+++ b/frontend/src/pages/NewFile/images/PDA.tsx
@@ -4,7 +4,7 @@ const PDA = ({ stateFill, strokeColor }: { stateFill: string, strokeColor: strin
   return (
     <svg viewBox="364 324 347 192">
       <defs>
-        <marker id="standard-arrow-head" strokeWidth="2" markerHeight="30" markerUnits="2" markerWidth="30" orient="auto" refX="29" refY="15">
+        <marker id="standard-arrow-head" strokeWidth="2" markerHeight="30" markerUnits="strokeWidth" markerWidth="30" orient="auto" refX="29" refY="15">
           <path fill={strokeColor} d="M29 15l-7.208-3.471v6.942z" strokeWidth="2"></path>
         </marker>
         <marker strokeWidth="2" markerHeight="30" markerUnits="strokeWidth" markerWidth="30" orient="auto" refX="29" refY="15" >

--- a/frontend/src/pages/NewFile/images/TM.tsx
+++ b/frontend/src/pages/NewFile/images/TM.tsx
@@ -4,7 +4,7 @@ const TM = ({ stateFill, strokeColor }: { stateFill: string, strokeColor: string
   return (
     <svg viewBox="454 384 362 192">
       <defs>
-        <marker id="standard-arrow-head" strokeWidth="2" markerHeight="30" markerUnits="2" markerWidth="30" orient="auto" refX="29" refY="15">
+        <marker id="standard-arrow-head" strokeWidth="2" markerHeight="30" markerUnits="strokeWidth" markerWidth="30" orient="auto" refX="29" refY="15">
           <path fill={strokeColor} d="M29 15l-7.208-3.471v6.942z" strokeWidth="2"></path>
         </marker>
         <marker strokeWidth="2" markerHeight="30" markerUnits="strokeWidth" markerWidth="30" orient="auto" refX="29" refY="15" >


### PR DESCRIPTION
Closes #367 

The issue was some attribute where getting incorrectly used

- Width and height needed to passed as style properties, the `width` and `height` attribute [are for pixels](https://www.w3schools.com/tags/att_width.asp) and so `rem` cannot be used. This caused some uses of the logo to become smaller since it was now using the proper size, I made these instances use a blank size which achieves the same effect
- `markerUnits` only accepts [userSpaceOnUse and strokeWidth](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/markerUnits). I just used `strokeWidth` since it is used in other places and this didn't change any looks for me