### PR TITLE
Remove useless minimize button in tools

### DIFF
--- a/frontend/src/components/Menubar/menus.ts
+++ b/frontend/src/components/Menubar/menus.ts
@@ -153,10 +153,6 @@ const menus: ContextItems = [
         label: 'Convert to DFA',
         action: 'CONVERT_TO_DFA'
       },
-      {
-        label: 'Minimize DFA',
-        action: 'MINIMIZE_DFA'
-      },
       'hr',
       {
         label: 'Auto layout',

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -326,10 +326,6 @@ const useActions = (registerHotkeys = false) => {
         }
       }
     },
-    MINIMIZE_DFA: {
-      disabled: () => true,
-      handler: () => console.log('Minimize DFA')
-    },
     AUTO_LAYOUT: {
       disabled: () => true,
       handler: () => console.log('Auto Layout')


### PR DESCRIPTION
Closes #239 

As title says, removes the minimize dfa button from tools as my nfa-to-dfa converter does that already.
![Screenshot 2023-05-18 164438](https://github.com/automatarium/automatarium/assets/117334212/0bed2938-55a1-4b59-a931-18e9b59b5975)
