### PR TITLE
Pass innerRef directly to remove react error

### DIFF
--- a/frontend/src/pages/NewFile/components/CardList/CardList.tsx
+++ b/frontend/src/pages/NewFile/components/CardList/CardList.tsx
@@ -7,13 +7,13 @@ interface CardListProps extends HTMLAttributes<HTMLDivElement> {
   innerRef?: Ref<HTMLDivElement>
 }
 
-const CardList = ({ title, button, ...props }: CardListProps) => (
+const CardList = ({ title, button, innerRef, ...props }: CardListProps) => (
   <section>
     <CardListTitleContainer>
       {title && <CardListTitle>{title}</CardListTitle>}
       {button}
     </CardListTitleContainer>
-    <CardListContainer ref={props.innerRef} {...props} />
+    <CardListContainer ref={innerRef} {...props} />
   </section>
 )
 


### PR DESCRIPTION
I had this change but seems I forgot to commit it in the PR.

This just tells React that it should expect the `innerRef` parameter so it doesn't error in the console anymore (didn't seem to affect functionality, but was annoying)