### PR TITLE
Use `nextIDFor` in places that need a new ID

### DIFF
--- a/frontend/src/stores/useProjectStore.ts
+++ b/frontend/src/stores/useProjectStore.ts
@@ -80,13 +80,10 @@ export const createNewProject = (projectType: ProjectType = DEFAULT_PROJECT_TYPE
  * but instead returns the number of the highest
  * e.g. [1, 4, 7] next ID would be 8
  */
-const nextIDFor = (elementArr: {id?: number}[]): number => {
+const nextIDFor = (elementArr: {id: number}[]): number => {
   // We can't do elementArr.length + 1 since that might reuse an ID from a deleted item.
-  // Order also is guarenteed so we can't just get the last element.
-  let highest = Math.max(-1, ...elementArr.map(e => e.id))
-  // If any of the IDs were undefined then `highest` would be NaN
-  if (isNaN(highest)) highest = -1
-  return 1 + highest
+  // Order also is guaranteed so we can't just get the last element.
+  return 1 + Math.max(-1, ...elementArr.map(e => e.id))
 }
 
 interface ProjectStore {
@@ -109,7 +106,7 @@ interface ProjectStore {
   setName: (name: string) => void,
   createTransition: (transition: BaseAutomataTransition) => number,
   editTransition: (transition: Omit<BaseAutomataTransition, 'from' | 'to'>) => void,
-  createComment: (comment: ProjectComment) => number,
+  createComment: (comment: Omit<ProjectComment, 'id'>) => number,
   updateComment: (comment: ProjectComment) => void,
   removeComment: (comment: ProjectComment) => void,
   createState: (state: Omit<AutomataState, 'isFinal' | 'id'>) => number,
@@ -222,7 +219,7 @@ const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectSto
   })),
 
   /* Create a new comment */
-  createComment: (comment: ProjectComment) => {
+  createComment: comment => {
     const id = nextIDFor(get().project.comments)
     set(produce(({ project }: { project: StoredProject }) => {
       project.comments.push({ ...comment, id })

--- a/frontend/src/types/ProjectTypes.ts
+++ b/frontend/src/types/ProjectTypes.ts
@@ -41,7 +41,7 @@ export interface ProjectComment {
     x: number,
     y: number,
     text: string,
-    id?: number
+    id: number
 }
 
 export interface AutomataState {


### PR DESCRIPTION
Followup to a comment in #348, this uses the `nextIDFor` in all the places that we calculate the ID.
Issue with my original comment was that if the highest was 0 then `0 || -1` would evaluate to -1 and so the ID returned would be 0 (when it should be 1).

I instead updated the type on `ProjectComment` to reflect that the `id` isn't optional since its given one when created and then did away with my original `NaN` check