### PR TITLE
Fix reordering sort and small cleanup

### DIFF
--- a/packages/simulation/tests/graphs/highSort.json
+++ b/packages/simulation/tests/graphs/highSort.json
@@ -1,0 +1,60 @@
+{
+  "projectType": "FSA",
+  "_id": "fddccedc-97b0-4ec8-ac54-c59b5fdd8a4b",
+  "states": [
+    {
+      "x": 540,
+      "y": 375,
+      "id": 0,
+      "isFinal": false
+    },
+    {
+      "x": 690,
+      "y": 330,
+      "id": 3,
+      "isFinal": false
+    },
+    {
+      "x": 615,
+      "y": 510,
+      "id": 10,
+      "isFinal": false
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "to": 3,
+      "id": 0,
+      "read": "A"
+    },
+    {
+      "from": 0,
+      "to": 10,
+      "id": 2,
+      "read": "B"
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Joyous Leaf Blower",
+    "dateCreated": 1686025278840,
+    "dateEdited": 1686025278840,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "FSA",
+    "statePrefix": "q",
+    "acceptanceCriteria": "both",
+    "color": "orange"
+  }
+}

--- a/packages/simulation/tests/reorderGraph.test.ts
+++ b/packages/simulation/tests/reorderGraph.test.ts
@@ -3,6 +3,7 @@ import { reorderStates } from '../src/reorder'
 import dibDipLambdaLoop from './graphs/dib_dip-lambdaloop.json'
 import spiggy from './graphs/spiggy.json'
 import { FSAProjectGraph, TMProjectGraph } from 'frontend/src/types/ProjectTypes'
+import highSort from './graphs/highSort.json'
 
 describe('Reordering graph', () => {
   test('Simple graph can be rearranged', () => {
@@ -152,5 +153,13 @@ describe('Reordering graph', () => {
     const graph = reorderStates(spiggy as FSAProjectGraph)
     // Check that the state numbers are continuous
     expect(graph.states.map(it => it.id).sort()).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8])
+  })
+
+  test('IDs are sorted correctly', () => {
+    const graph = reorderStates(highSort as FSAProjectGraph)
+    // q10 should be mapped to q2 since it was previously the highest
+    const highest = graph.transitions.find(t => t.to === 2)
+    // Transition from q0 to q10 reads B
+    expect(highest.read).toBe('B')
   })
 })


### PR DESCRIPTION
Was looking over the implementation and noticed I did sorting wrong (e.g. it would think `10 < 4`) so added test case and then fixed that up. 

Did a bit of clean up while I was there
- Use `t` when iterating through transitions like is convention with other places
- Clean up logic inside frontier exploration. Removes redundant checks and saves filtering the list twice
- Use optional access instead of creating a temporary list
- Use `Map` instead of `Object` since it makes more sense and is usually more efficient (not that it really matters at this small a scale)