### PR TITLE
Move graph reordering from right-click menu into the Tools dropdown.

### DIFF
--- a/frontend/src/components/ContextMenus/graphContextItems.ts
+++ b/frontend/src/components/ContextMenus/graphContextItems.ts
@@ -10,10 +10,6 @@ const graphContextItems: ContextItems = [
     label: 'Create state here',
     action: 'CREATE_STATE'
   },
-  {
-    label: 'Reorder graph',
-    action: 'REORDER_GRAPH'
-  },
   'hr',
   {
     label: 'Select all',

--- a/frontend/src/components/Menubar/menus.ts
+++ b/frontend/src/components/Menubar/menus.ts
@@ -157,6 +157,10 @@ const menus: ContextItems = [
       {
         label: 'Auto layout',
         action: 'AUTO_LAYOUT'
+      },
+      {
+        label: 'Reorder graph',
+        action: 'REORDER_GRAPH'
       }
     ]
   },


### PR DESCRIPTION
I felt it makes sense to have it in Tools since it doesn't depend on where the user right clicks

![image](https://github.com/automatarium/automatarium/assets/19339842/39b09505-df5b-4bac-9a2b-3f17e64081b7)
