### PR TITLE
Batch updates during dragging for increased performance

### DIFF
--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -380,7 +380,7 @@ const useActions = (registerHotkeys = false) => {
         const states = storeState?.project?.states?.filter(s => selected.includes(s.id))
         if (states && states.length > 1) {
           const meanY = states.map(state => state.y).reduce((a, b) => a + b) / states.length
-          states.forEach(state => storeState.updateState({ ...state, y: meanY }))
+          storeState.updateStates(states.map(state => ({ ...state, y: meanY })))
           commit()
         }
       }
@@ -393,7 +393,7 @@ const useActions = (registerHotkeys = false) => {
         const states = storeState?.project?.states?.filter(s => selected.includes(s.id))
         if (states && states.length > 1) {
           const meanX = states.map(state => state.x).reduce((a, b) => a + b) / states.length
-          states.forEach(state => storeState.updateState({ ...state, x: meanX }))
+          storeState.updateStates(states.map(state => ({ ...state, x: meanX })))
           commit()
         }
       }

--- a/frontend/src/hooks/useCommentDragging.ts
+++ b/frontend/src/hooks/useCommentDragging.ts
@@ -1,6 +1,6 @@
 import { useProjectStore } from '/src/stores'
 
-import useResourceDragging, { ResourceDraggingHook } from './useResourceDragging'
+import useResourceDragging from './useResourceDragging'
 import { ProjectComment } from '/src/types/ProjectTypes'
 
 /**
@@ -14,7 +14,6 @@ const commentsFromIDs = (IDs: number[]): CommentWithID[] => {
   return comments.filter(comment => IDs.includes(comment.id)) as CommentWithID[]
 }
 
-const makeUpdateComment = () => useProjectStore(s => s.updateComment)
+const makeUpdateComments = () => useProjectStore(s => s.updateComments)
 
-// export default () => useResourceDragging(commentsFromIDs, makeUpdateComment)
-export default useResourceDragging.bind(null, commentsFromIDs, makeUpdateComment) as () => ResourceDraggingHook
+export default () => useResourceDragging(commentsFromIDs, makeUpdateComments)

--- a/frontend/src/hooks/useResourceDragging.ts
+++ b/frontend/src/hooks/useResourceDragging.ts
@@ -16,15 +16,15 @@ export type ResourceDraggingHook = {startDrag: (e: DragEvent, ids: number[]) => 
 /**
  * Handles dragging of resources (e.g. comments, states)
  * @param resourcesFromIDs Function takes a list of IDs and returns resources with those IDs
- * @param makeUpdateResource Function that updates the resource in the store
+ * @param makeUpdateResources Function that updates the resource in the store
  */
 const useResourceDragging = <T extends RequiredProps>(
   resourcesFromIDs: (IDs: number[]) => T[],
-  makeUpdateResource: () => (x: Partial<T>) => void): ResourceDraggingHook => {
+  makeUpdateResources: () => (x: Partial<T>[]) => void): ResourceDraggingHook => {
   const tool = useToolStore(s => s.tool)
   const toolActive = tool === 'cursor'
 
-  const updateResource = makeUpdateResource()
+  const updateResources = makeUpdateResources()
   const commit = useProjectStore(s => s.commit)
   const screenToViewSpace = useViewStore(s => s.screenToViewSpace)
 
@@ -48,7 +48,7 @@ const useResourceDragging = <T extends RequiredProps>(
   // Listen for mouse move - dragging states
   useEvent('svg:mousemove', e => {
     if (dragging !== null && toolActive) {
-      dragging.forEach((id, i) => {
+      const updates = dragging.map((id, i) => {
         const [x, y] = [e.detail.viewX, e.detail.viewY]
         const [dx, dy] = [x - dragOffsets[i][0], y - dragOffsets[i][1]]
 
@@ -70,9 +70,9 @@ const useResourceDragging = <T extends RequiredProps>(
             ? [Math.floor(dx / GRID_SNAP) * GRID_SNAP, Math.floor(dy / GRID_SNAP) * GRID_SNAP]
             : [(Math.floor(lx / GRID_SNAP) * GRID_SNAP) + lox, Math.floor(ly / GRID_SNAP) * GRID_SNAP + loy]
 
-        // Update state position
-        updateResource({ id, x: sx, y: sy } as Partial<T>)
+        return { id, x: sx, y: sy } as Partial<T>
       })
+      updateResources(updates)
     }
   }, [toolActive, dragging, gridVisible])
 

--- a/frontend/src/hooks/useStateDragging.ts
+++ b/frontend/src/hooks/useStateDragging.ts
@@ -1,6 +1,6 @@
 import { useProjectStore } from '/src/stores'
 
-import useResourceDragging, { ResourceDraggingHook } from './useResourceDragging'
+import useResourceDragging from './useResourceDragging'
 import { AutomataState } from '/src/types/ProjectTypes'
 
 // Setup state interactivity deps
@@ -8,6 +8,6 @@ const statesFromIDs = (IDs: number[]): AutomataState[] => {
   const states = useProjectStore.getState()?.project?.states ?? []
   return states.filter(state => IDs.includes(state.id))
 }
-const makeUpdateState = () => useProjectStore(s => s.updateState)
+const makeUpdateStates = () => useProjectStore(s => s.updateStates)
 
-export default useResourceDragging.bind(null, statesFromIDs, makeUpdateState) as () => ResourceDraggingHook
+export default () => useResourceDragging(statesFromIDs, makeUpdateStates)

--- a/frontend/src/stores/useProjectStore.ts
+++ b/frontend/src/stores/useProjectStore.ts
@@ -107,10 +107,12 @@ interface ProjectStore {
   createTransition: (transition: Omit<BaseAutomataTransition, 'id' | 'read'>) => number,
   editTransition: (transition: Omit<BaseAutomataTransition, 'from' | 'to'>) => void,
   createComment: (comment: Omit<ProjectComment, 'id'>) => number,
-  updateComment: (comment: ProjectComment) => void,
+  updateComment: (comment: Partial<ProjectComment>) => void,
+  updateComments: (comments: Partial<ProjectComment>[]) => void,
   removeComment: (comment: ProjectComment) => void,
   createState: (state: Omit<AutomataState, 'isFinal' | 'id'> & {isFinal?: boolean}) => number,
-  updateState: (state: AutomataState) => void,
+  updateState: (state: Partial<AutomataState>) => void,
+  updateStates: (states: Partial<AutomataState>[]) => void,
   insertGroup: (createData: Template | CopyData, isTemplate?: boolean) => InsertGroupResponse,
   setSingleTest: (value: string) => void,
   addBatchTest: (value?: string) => void,
@@ -229,7 +231,15 @@ const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectSto
 
   /* Update a comment by id */
   updateComment: (comment: ProjectComment) => set(produce(({ project }: { project: StoredProject }) => {
-    project.comments = project.comments.map((cm: ProjectComment) => cm.id === comment.id ? { ...cm, ...comment } : cm)
+    const index = project.comments.findIndex(s => s.id === comment.id)
+    project.comments[index] = { ...project.comments[index], ...comment }
+  })),
+
+  updateComments: comments => set(produce(({ project }: { project: StoredProject }) => {
+    for (const comment of comments) {
+      const index = project.comments.findIndex(s => s.id === comment.id)
+      project.comments[index] = { ...project.comments[index], ...comment }
+    }
   })),
 
   /* Remove a comment by id */
@@ -248,7 +258,15 @@ const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectSto
 
   /* Update a state by id */
   updateState: (state: AutomataState) => set(produce(({ project }: { project: StoredProject }) => {
-    project.states = project.states.map((st: AutomataState) => st.id === state.id ? { ...st, ...state } : st)
+    const index = project.states.findIndex(s => s.id === state.id)
+    project.states[index] = { ...project.states[index], ...state }
+  })),
+
+  updateStates: states => set(produce(({ project }: { project: StoredProject }) => {
+    for (const state of states) {
+      const index = project.states.findIndex(s => s.id === state.id)
+      project.states[index] = { ...project.states[index], ...state }
+    }
   })),
 
   /* Remove a state by id */

--- a/frontend/src/stores/useProjectStore.ts
+++ b/frontend/src/stores/useProjectStore.ts
@@ -137,6 +137,15 @@ interface ProjectStore {
   reset: () => void
 }
 
+/**
+ * Updates an item with the same ID from a list of items.
+ * Expects the item to exist in items
+ */
+const updateById = <T extends {id: number}>(items: T[], item: Partial<T>) => {
+  const index = items.findIndex(x => x.id === item.id)
+  items[index] = { ...items[index], ...item }
+}
+
 const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectStore>, get: GetState<ProjectStore>) => ({
   project: null as StoredProject,
   history: [],
@@ -230,15 +239,13 @@ const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectSto
   },
 
   /* Update a comment by id */
-  updateComment: (comment: ProjectComment) => set(produce(({ project }: { project: StoredProject }) => {
-    const index = project.comments.findIndex(s => s.id === comment.id)
-    project.comments[index] = { ...project.comments[index], ...comment }
+  updateComment: comment => set(produce(({ project }: { project: StoredProject }) => {
+    updateById(project.comments, comment)
   })),
 
   updateComments: comments => set(produce(({ project }: { project: StoredProject }) => {
     for (const comment of comments) {
-      const index = project.comments.findIndex(s => s.id === comment.id)
-      project.comments[index] = { ...project.comments[index], ...comment }
+      updateById(project.comments, comment)
     }
   })),
 
@@ -257,15 +264,13 @@ const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectSto
   },
 
   /* Update a state by id */
-  updateState: (state: AutomataState) => set(produce(({ project }: { project: StoredProject }) => {
-    const index = project.states.findIndex(s => s.id === state.id)
-    project.states[index] = { ...project.states[index], ...state }
+  updateState: state => set(produce(({ project }: { project: StoredProject }) => {
+    updateById(project.states, state)
   })),
 
   updateStates: states => set(produce(({ project }: { project: StoredProject }) => {
     for (const state of states) {
-      const index = project.states.findIndex(s => s.id === state.id)
-      project.states[index] = { ...project.states[index], ...state }
+      updateById(project.states, state)
     }
   })),
 


### PR DESCRIPTION
Performance would sometimes be sluggish on my laptop or with large machines so I profiled the code to find the problem.
Issue is that updating state is a very expensive operation for react and dragging would update the state a lot. By batching the updates together this improves the performance by a lot.

Another thing I tried to improve performance was move everything that used `number[]` to use `Set<number>` instead but that didn't help with performance

**Before PR**
![slow](https://github.com/automatarium/automatarium/assets/19339842/30230da2-fd44-480e-acf2-f75cbdd531d2)

**After PR**
![fast](https://github.com/automatarium/automatarium/assets/19339842/6e2300b9-3cd7-472f-87f3-3595377d3b91)



[Benchmark file used](https://pastebin.com/75AuYB2c)
