### PR TITLE
Fix items being dragged even if they are not selected

### DIFF
--- a/frontend/src/components/EditorPanel/EditorPanel.tsx
+++ b/frontend/src/components/EditorPanel/EditorPanel.tsx
@@ -29,8 +29,8 @@ const EditorPanel = () => {
   const { ghostState } = useStateCreation()
   const { ghostTemplate } = useTemplateInsert()
 
-  const selectedStates = useSelectionStore(s => s.selectedStates)
-  const selectedComments = useSelectionStore(s => s.selectedComments)
+  let selectedStates = useSelectionStore(s => s.selectedStates)
+  let selectedComments = useSelectionStore(s => s.selectedComments)
 
   const setStates = useSelectionStore(s => s.setStates)
   const setComments = useSelectionStore(s => s.setComments)
@@ -42,12 +42,30 @@ const EditorPanel = () => {
   useContextMenus()
 
   const handleDragging = (e: SelectionEvent) => {
+    const isLeftClick = e.detail.originalEvent.button === 0
+    // When the user isn't holding shift and is just clicking then we need to check if we
+    // need to clear their selection.
+    if (!e.detail.originalEvent.shiftKey && isLeftClick) {
+      // Runs a test to see if the item being selected in the event is already selected.
+      // If it isn't then we forget what we have selected before
+      const testEvent = (eventKey: string, ids: number[]) => {
+        if (eventKey in e.detail) {
+          if (!ids.includes(e.detail[eventKey].id)) {
+            selectedComments = []
+            selectedStates = []
+          }
+        }
+      }
+      testEvent('comment', selectedComments)
+      testEvent('state', selectedStates)
+    }
     // Only try and check if the user is selecting a new resource if the event correlates with that.
     // Else just use the previous value from the store.
-    // Outside the if so that you can directly right-click and edit a state
     const selStates = e.type === 'state:mousedown' ? selectState(e) : selectedStates
     const selComments = e.type === 'comment:mousedown' ? selectComment(e) : selectedComments
-    if (e.detail.originalEvent.button === 0) {
+    if (isLeftClick) {
+      // Only drag if a left click.
+      // We still allow selecting via right click so the user can directly click + edit something
       startStateDrag(e, selStates)
       startCommentDrag(e, selComments)
     }

--- a/frontend/src/hooks/useTransitionCreation.ts
+++ b/frontend/src/hooks/useTransitionCreation.ts
@@ -3,16 +3,18 @@ import { useState } from 'react'
 import { useEvent } from '/src/hooks'
 import { useProjectStore, useToolStore, useViewStore } from '/src/stores'
 import { dispatchCustomEvent } from '/src/util/events'
+import { AutomataState, Coordinate } from '/src/types/ProjectTypes'
 
-const useTransitionCreation = () => {
+const useTransitionCreation = (): {createTransitionStart: Coordinate, createTransitionEnd: Coordinate} => {
   const createTransition = useProjectStore(s => s.createTransition)
   const tool = useToolStore(s => s.tool)
 
   const screenToViewSpace = useViewStore(s => s.screenToViewSpace)
-
-  const [createTransitionStart, setCreateTransitionStart] = useState(null)
-  const [createTransitionState, setCreateTransitionState] = useState(null)
-  const [createTransitionEnd, setCreateTransitionEnd] = useState(null)
+  // Alias for whats used in the next states
+  type PosTuple = [number, number] | null
+  const [createTransitionStart, setCreateTransitionStart] = useState<PosTuple>(null)
+  const [createTransitionState, setCreateTransitionState] = useState<AutomataState>(null)
+  const [createTransitionEnd, setCreateTransitionEnd] = useState<PosTuple>(null)
 
   useEvent('state:mousedown', e => {
     if (tool === 'transition' && e.detail.originalEvent.button === 0) {

--- a/frontend/src/hooks/useTransitionCreation.ts
+++ b/frontend/src/hooks/useTransitionCreation.ts
@@ -5,7 +5,7 @@ import { useProjectStore, useToolStore, useViewStore } from '/src/stores'
 import { dispatchCustomEvent } from '/src/util/events'
 import { AutomataState, Coordinate } from '/src/types/ProjectTypes'
 
-const useTransitionCreation = (): {createTransitionStart: Coordinate, createTransitionEnd: Coordinate} => {
+const useTransitionCreation = (): { createTransitionStart: Coordinate, createTransitionEnd: Coordinate } => {
   const createTransition = useProjectStore(s => s.createTransition)
   const tool = useToolStore(s => s.tool)
 


### PR DESCRIPTION
Hopefully this is the last bug squashed from #370. Issue was states that were previously selected were still being dragged even if not selected.

**Before**
![Dragging being spooky](https://github.com/automatarium/automatarium/assets/19339842/b4387286-3362-4688-bdd1-839ba9ffca95)

**After**
![Recording 2023-07-01 at 22 22 30](https://github.com/automatarium/automatarium/assets/19339842/cbce53e6-27a8-451e-bc21-2f8c0e86113d)

