### PR TITLE
Transition edge context menu

### DIFF
--- a/frontend/src/components/ContextMenus/ContextMenus.tsx
+++ b/frontend/src/components/ContextMenus/ContextMenus.tsx
@@ -7,6 +7,7 @@ import graphContextItems from './graphContextItems'
 import stateContextItems from './stateContextItems'
 import transitionContextItems from './transitionContextItems'
 import commentContextItems from './commentContextItems'
+import edgeContextItems from './edgeContextItems'
 import { ContextItems } from './contextItem'
 
 const ContextMenus = () => {
@@ -26,6 +27,10 @@ const ContextMenus = () => {
 
   useEvent('ctx:comment', ({ detail: { x, y } }) => {
     setContext({ visible: true, x, y, items: commentContextItems })
+  }, [])
+
+  useEvent('ctx:edge', ({ detail: { x, y } }) => {
+    setContext({ visible: true, x, y, items: edgeContextItems })
   }, [])
 
   if (!context?.visible) return null

--- a/frontend/src/components/ContextMenus/edgeContextItems.tsx
+++ b/frontend/src/components/ContextMenus/edgeContextItems.tsx
@@ -1,0 +1,10 @@
+import { ContextItems } from './contextItem'
+
+const edgeContextItems: ContextItems = [
+  {
+    label: 'Edit transitions group',
+    action: 'EDIT_TRANSITIONS_GROUP'
+  }
+]
+
+export default edgeContextItems

--- a/frontend/src/components/ContextMenus/edgeContextItems.tsx
+++ b/frontend/src/components/ContextMenus/edgeContextItems.tsx
@@ -4,6 +4,11 @@ const edgeContextItems: ContextItems = [
   {
     label: 'Edit transitions group',
     action: 'EDIT_TRANSITIONS_GROUP'
+  },
+  'hr',
+  {
+    label: 'Delete edge',
+    action: 'DELETE_EDGE'
   }
 ]
 

--- a/frontend/src/components/EditorPanel/EditorPanel.tsx
+++ b/frontend/src/components/EditorPanel/EditorPanel.tsx
@@ -1,5 +1,5 @@
 import StateCircle from '../StateCircle/StateCircle'
-import { GraphContent, GraphView, SelectionBox, TransitionSet, ContextMenus, InputDialogs } from '/src/components'
+import { GraphContent, GraphView, SelectionBox, TransitionSet, ContextMenus, InputDialogs, InputTransitionGroup } from '/src/components'
 import {
   useEvent,
   useStateDragging,
@@ -135,6 +135,7 @@ const EditorPanel = () => {
     </GraphView>
     <ContextMenus />
     <InputDialogs />
+    <InputTransitionGroup />
   </>
 }
 

--- a/frontend/src/components/EditorPanel/EditorPanel.tsx
+++ b/frontend/src/components/EditorPanel/EditorPanel.tsx
@@ -15,7 +15,7 @@ import {
 } from '/src/hooks'
 import { SelectionEvent } from '/src/hooks/useResourceSelection'
 import { useSelectionStore, useTemplateStore } from '/src/stores'
-import { CommentEventData, StateEventData, TransitionEventData } from '/src/hooks/useEvent'
+import { CommentEventData, EdgeEventData, StateEventData, TransitionEventData } from '/src/hooks/useEvent'
 import TemplateGhost from '../Template/TemplateGhost'
 
 const EditorPanel = () => {
@@ -101,7 +101,7 @@ const EditorPanel = () => {
     }
     selectTransition(newEvent)
   })
-  useEvent('edge:dblclick', e => {
+  useEvent('edge:dblclick', (e: CustomEvent<EdgeEventData>) => {
     setStates([])
     setComments([])
     setTransitions(e.detail.transitions.map(t => t.id))

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -1,5 +1,5 @@
 import { CornerDownLeft } from 'lucide-react'
-import { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { ChangeEvent, useEffect, useState } from 'react'
 import { InputSpacingWrapper } from './inputTransitionGroupStyle'
 import Button from '/src/components/Button/Button'
 import Input from '/src/components/Input/Input'
@@ -38,6 +38,8 @@ const InputTransitionGroup = () => {
     // Do preliminary store updates
     setIdList([...ids])
     const transitionsScope = transitions.filter(t => ids.includes(t.id))
+    // Somehow you can select nothing sometimes. This prevents a crash
+    if (transitionsScope.length === 0) return null
     // All of these should be part of the same transition edge
     setFromState(transitionsScope[0].from)
     setToState(transitionsScope[0].to)
@@ -287,45 +289,51 @@ const InputTransitionGroup = () => {
         assertType<Array<TMAutomataTransition>>(transitionsList)
         return <>
           {transitionsList.map((t, i) => <InputWrapper key={i}>
-            <Input
-              value={t.read}
-              onChange={e => {
-                const r = tmReadWriteValidate(e)
-                saveTMTransition({
-                  id: t.id,
-                  read: r,
-                  write: t.write,
-                  direction: t.direction
-                })
-              }}
-              placeholder={'λ\t(read)'}
-            />
-            <Input
-              value={t.write}
-              onChange={e => {
-                const w = tmReadWriteValidate(e)
-                saveTMTransition({
-                  id: t.id,
-                  read: t.read,
-                  write: w,
-                  direction: t.direction
-                })
-              }}
-              placeholder={'λ\t(write)'}
-            />
-            <Input
-              value={t.direction}
-              onChange={e => {
-                const d = tmDirectionValidate(e)
-                saveTMTransition({
-                  id: t.id,
-                  read: t.read,
-                  write: t.write,
-                  direction: d
-                })
-              }}
-              placeholder={'↔\t(direction)'}
-            />
+            <InputSpacingWrapper>
+              <Input
+                value={t.read}
+                onChange={e => {
+                  const r = tmReadWriteValidate(e)
+                  saveTMTransition({
+                    id: t.id,
+                    read: r,
+                    write: t.write,
+                    direction: t.direction
+                  })
+                }}
+                placeholder={'λ\t(read)'}
+                />
+            </InputSpacingWrapper>
+            <InputSpacingWrapper>
+              <Input
+                value={t.write}
+                onChange={e => {
+                  const w = tmReadWriteValidate(e)
+                  saveTMTransition({
+                    id: t.id,
+                    read: t.read,
+                    write: w,
+                    direction: t.direction
+                  })
+                }}
+                placeholder={'λ\t(write)'}
+                />
+            </InputSpacingWrapper>
+            <InputSpacingWrapper>
+              <Input
+                value={t.direction}
+                onChange={e => {
+                  const d = tmDirectionValidate(e)
+                  saveTMTransition({
+                    id: t.id,
+                    read: t.read,
+                    write: t.write,
+                    direction: d
+                  })
+                }}
+                placeholder={'↔\t(direction)'}
+                />
+            </InputSpacingWrapper>
           </InputWrapper>
           )}
           <hr/>

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -207,9 +207,11 @@ const InputTransitionGroup = () => {
     return input[input.length - 1] ?? ''
   }
 
-  /** Copied over from InputDialogs handleDirectionIn @see InputDialogs */
+  /** Copied over from InputDialogs handleDirectionIn @see InputDialogs.tsx */
   const tmDirectionValidate = (e: ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value.toString().match(/[rls]|^$/gi)
+    // TODO: catch error and show user a dialog saying its invalid rather than forcing to R
+    if (input === null) return 'R' as TMDirection
     const value = input[input.length - 1].toUpperCase()
     return value as TMDirection
   }

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react'
+import { useEvent } from '/src/hooks'
+import { useProjectStore } from '/src/stores'
+import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, TMAutomataTransition, assertType } from '/src/types/ProjectTypes'
+import Modal from '../Modal/Modal'
+import Button from '../Button/Button'
+import Input from '../Input/Input'
+import { InputWrapper } from '../InputDialogs/inputDialogsStyle'
+
+const InputTransitionGroup = () => {
+  const [fromState, setFromState] = useState<number>()
+  const [toState, setToState] = useState<number>()
+  const [transitionsList, setTransitionsList] = useState<Array<BaseAutomataTransition> | undefined>()
+
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const statePrefix = useProjectStore(s => s.project.config.statePrefix)
+  const projectType = useProjectStore(s => s.project.config.type)
+  // Get data from event dispatch
+  useEvent('editTransitionGroup', ({ detail: { ids } }) => {
+    // Get transitions from store
+    const { transitions } = useProjectStore.getState()?.project ?? {}
+    const transitionsScope = transitions.filter(t => ids.includes(t.id))
+    // All of these should be part of the same transition edge
+    setFromState(transitionsScope[0].from)
+    setToState(transitionsScope[0].to)
+    setTransitionsList(transitionsScope)
+    setModalOpen(true)
+  })
+
+  if (!transitionsList) return null
+
+  function contents () {
+    switch (projectType) {
+      case 'FSA':
+        assertType<Array<FSAAutomataTransition>>(transitionsList)
+        return transitionsList.map(t => <Input
+          key={t.id}
+          value={t.read}
+          placeholder={'λ'}
+        />
+        )
+      case 'PDA':
+        assertType<Array<PDAAutomataTransition>>(transitionsList)
+        return transitionsList.map(t => <InputWrapper key={t.id}>
+            <Input value={t.read} placeholder={'λ\t(read)'} />
+            <Input value={t.pop} placeholder={'λ\t(pop)'} />
+            <Input value={t.push} placeholder={'λ\t(push)'} />
+          </InputWrapper>)
+      case 'TM':
+        assertType<Array<TMAutomataTransition>>(transitionsList)
+        return transitionsList.map(t => <InputWrapper key={t.id}>
+          <Input value={t.read} placeholder={'λ\t(read)'} />
+          <Input value={t.write} placeholder={'λ\t(write)'} />
+          <Input value={t.direction} placeholder={'↔\t(direction)'} />
+        </InputWrapper>)
+    }
+  }
+
+  return <Modal
+    title='Transition Edge Editor'
+    description={
+        'Editing transition from ' +
+        statePrefix + fromState + ' to ' +
+        statePrefix + toState + '.'
+      }
+    isOpen={modalOpen}
+    actions={<Button onClick={() => setModalOpen(false)}>Done</Button>}
+  >
+    <div>{contents()}</div>
+  </Modal>
+}
+
+export default InputTransitionGroup

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -350,7 +350,7 @@ const InputTransitionGroup = () => {
           <SubmitButton onClick={() => deleteTransition(i)}>
             <X size='18px'/>
           </SubmitButton>
-          </InputWrapper>)}
+          </InputWrapper>).reverse()}
           <hr/>
           Add a new transition?
           {blankFSAInput()}
@@ -419,7 +419,7 @@ const InputTransitionGroup = () => {
             <SubmitButton onClick={() => deleteTransition(i)}>
               <X size='18px'/>
             </SubmitButton>
-          </InputWrapper>)}
+          </InputWrapper>).reverse()}
           <hr/>
           Add a new transition?
           {blankPDAInput()}
@@ -492,7 +492,7 @@ const InputTransitionGroup = () => {
               <X size='18px'/>
             </SubmitButton>
           </InputWrapper>
-          )}
+          ).reverse()}
           <hr/>
           Add a new transition?
           {blankTMInput()}

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -1,12 +1,13 @@
+import { CornerDownLeft } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { useEvent } from '/src/hooks'
-import { useProjectStore } from '/src/stores'
-import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, TMAutomataTransition, assertType } from '/src/types/ProjectTypes'
-import Modal from '/src/components/Modal/Modal'
+import { InputSpacingWrapper } from './inputTransitionGroupStyle'
 import Button from '/src/components/Button/Button'
 import Input from '/src/components/Input/Input'
 import { InputWrapper, SubmitButton } from '/src/components/InputDialogs/inputDialogsStyle'
-import { CornerDownLeft } from 'lucide-react'
+import Modal from '/src/components/Modal/Modal'
+import { useEvent } from '/src/hooks'
+import { useProjectStore } from '/src/stores'
+import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, TMAutomataTransition, assertType } from '/src/types/ProjectTypes'
 
 const InputTransitionGroup = () => {
   const [fromState, setFromState] = useState<number>()
@@ -117,21 +118,27 @@ const InputTransitionGroup = () => {
   }
 
   const blankPDAInput = () => <InputWrapper>
-    <Input
-      value={readValue}
-      onChange={e => setReadValue(e.target.value)}
-      placeholder={'λ\t(read)'}
-    />
-    <Input
-      value={popValue}
-      onChange={e => setPopValue(e.target.value)}
-      placeholder={'λ\t(pop)'}
-    />
-    <Input
-      value={pushValue}
-      onChange={e => setPushValue(e.target.value)}
-      placeholder={'λ\t(push)'}
-    />
+    <InputSpacingWrapper>
+      <Input
+        value={readValue}
+        onChange={e => setReadValue(e.target.value)}
+        placeholder={'λ\t(read)'}
+        />
+    </InputSpacingWrapper>
+    <InputSpacingWrapper>
+      <Input
+        value={popValue}
+        onChange={e => setPopValue(e.target.value)}
+        placeholder={'λ\t(pop)'}
+        />
+    </InputSpacingWrapper>
+    <InputSpacingWrapper>
+      <Input
+        value={pushValue}
+        onChange={e => setPushValue(e.target.value)}
+        placeholder={'λ\t(push)'}
+        />
+    </InputSpacingWrapper>
     <SubmitButton onClick={saveNewPDATransition}>
       <CornerDownLeft size='18px' />
     </SubmitButton>
@@ -159,21 +166,27 @@ const InputTransitionGroup = () => {
   }
 
   const blankTMInput = () => <InputWrapper>
-    <Input
-      value={readValue}
-      onChange={e => setReadValue(e.target.value)}
-      placeholder={'λ\t(read)'}
-    />
-    <Input
-      value={writeValue}
-      onChange={e => setWriteValue(e.target.value)}
-      placeholder={'λ\t(write)'}
-    />
-    <Input
-      value={dirValue}
-      onChange={e => setDirValue(e.target.value)}
-      placeholder={'↔\t(direction)'}
-    />
+    <InputSpacingWrapper>
+      <Input
+        value={readValue}
+        onChange={e => setReadValue(e.target.value)}
+        placeholder={'λ\t(read)'}
+        />
+    </InputSpacingWrapper>
+    <InputSpacingWrapper>
+      <Input
+        value={writeValue}
+        onChange={e => setWriteValue(e.target.value)}
+        placeholder={'λ\t(write)'}
+        />
+    </InputSpacingWrapper>
+    <InputSpacingWrapper>
+      <Input
+        value={dirValue}
+        onChange={e => setDirValue(e.target.value)}
+        placeholder={'↔\t(direction)'}
+        />
+    </InputSpacingWrapper>
     <SubmitButton onClick={saveNewTMTransition}>
       <CornerDownLeft size='18px' />
     </SubmitButton>
@@ -203,16 +216,19 @@ const InputTransitionGroup = () => {
         assertType<Array<PDAAutomataTransition>>(transitionsList)
         return <>
           {transitionsList.map((t, i) => <InputWrapper key={i}>
-            <Input
-              value={t.read}
-              onChange={e => savePDATransition({
-                id: t.id,
-                read: e.target.value,
-                pop: t.pop,
-                push: t.push
-              })}
-              placeholder={'λ\t(read)'}
-              />
+            <InputSpacingWrapper>
+              <Input
+                value={t.read}
+                onChange={e => savePDATransition({
+                  id: t.id,
+                  read: e.target.value,
+                  pop: t.pop,
+                  push: t.push
+                })}
+                placeholder={'λ'}
+                />
+            </InputSpacingWrapper>
+            <InputSpacingWrapper>
             <Input
               value={t.pop}
               onChange={e => savePDATransition({
@@ -221,18 +237,21 @@ const InputTransitionGroup = () => {
                 pop: e.target.value,
                 push: t.push
               })}
-              placeholder={'λ\t(pop)'}
+              placeholder={'λ'}
               />
-            <Input
-              value={t.push}
-              onChange={e => savePDATransition({
-                id: t.id,
-                read: t.read,
-                pop: t.pop,
-                push: e.target.value
-              })}
-              placeholder={'λ\t(push)'}
-            />
+            </InputSpacingWrapper>
+            <InputSpacingWrapper>
+              <Input
+                value={t.push}
+                onChange={e => savePDATransition({
+                  id: t.id,
+                  read: t.read,
+                  pop: t.pop,
+                  push: e.target.value
+                })}
+                placeholder={'λ'}
+                />
+            </InputSpacingWrapper>
           </InputWrapper>)}
           <hr/>
           {blankPDAInput()}

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -35,6 +35,9 @@ const InputTransitionGroup = () => {
   const [toState, setToState] = useState<number>()
   const [transitionsList, setTransitionsList] = useState<Array<BaseAutomataTransition> | undefined>()
 
+  const [fromName, setFromName] = useState<string>()
+  const [toName, setToName] = useState<string>()
+
   const [modalOpen, setModalOpen] = useState(false)
 
   const [idList, setIdList] = useState([])
@@ -56,15 +59,21 @@ const InputTransitionGroup = () => {
   // Get data from event dispatch
   useEvent('editTransitionGroup', ({ detail: { ids } }) => {
     // Get transitions from store
-    const { transitions } = useProjectStore.getState()?.project ?? {}
+    const { transitions, states } = useProjectStore.getState()?.project ?? {}
     // Do preliminary store updates
     setIdList([...ids])
     const transitionsScope = transitions.filter(t => ids.includes(t.id))
     // Somehow you can select nothing sometimes. This prevents a crash
     if (transitionsScope.length === 0) return null
     // All of these should be part of the same transition edge
-    setFromState(transitionsScope[0].from)
-    setToState(transitionsScope[0].to)
+    const f = transitionsScope[0].from
+    const t = transitionsScope[0].to
+    const fName = states.find(s => s.id === f).name ?? '' + statePrefix + f
+    const tName = states.find(s => s.id === t).name ?? '' + statePrefix + t
+    setFromState(f)
+    setToState(t)
+    setFromName(fName)
+    setToName(tName)
     setTransitionsList(transitionsScope)
     // Update ID list to include *ALL* transitions on this edge, including unselected
     // This will run the side effect of re-retrieving the updated id list when done
@@ -504,8 +513,8 @@ const InputTransitionGroup = () => {
     title='Transition Edge Editor'
     description={
         'Editing transition from ' +
-        statePrefix + fromState + ' to ' +
-        statePrefix + toState + '.'
+        fromName + ' to ' +
+        toName + '.'
       }
     isOpen={modalOpen}
     onClose={() => {

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -40,19 +40,19 @@ const InputTransitionGroup = () => {
     setTransitionsList([...transitionsScope])
   }
 
-  const saveFSATransition = (id, read) => {
+  const saveFSATransition = ({ id, read }) => {
     editTransition({ id, read })
     commit()
     retrieveTransitions()
   }
 
-  const savePDATransition = (id, read, pop, push) => {
+  const savePDATransition = ({ id, read, pop, push }) => {
     editTransition({ id, read, pop, push } as PDAAutomataTransition)
     commit()
     retrieveTransitions()
   }
 
-  const saveTMTransition = (id, read, write, direction) => {
+  const saveTMTransition = ({ id, read, write, direction }) => {
     editTransition({ id, read, write, direction: direction || 'R' } as TMAutomataTransition)
     commit()
     retrieveTransitions()
@@ -67,7 +67,7 @@ const InputTransitionGroup = () => {
         return transitionsList.map((t, i) => <Input
           key={i}
           value={t.read}
-          onChange={e => saveFSATransition(t.id, e.target.value)}
+          onChange={e => saveFSATransition({ id: t.id, read: e.target.value })}
           placeholder={'λ'}
         />
         )
@@ -76,17 +76,32 @@ const InputTransitionGroup = () => {
         return transitionsList.map((t, i) => <InputWrapper key={i}>
             <Input
               value={t.read}
-              onChange={e => savePDATransition(t.id, e.target.value, t.pop, t.push)}
+              onChange={e => savePDATransition({
+                id: t.id,
+                read: e.target.value,
+                pop: t.pop,
+                push: t.push
+              })}
               placeholder={'λ\t(read)'}
               />
             <Input
               value={t.pop}
-              onChange={e => savePDATransition(t.id, t.read, e.target.value, t.push)}
+              onChange={e => savePDATransition({
+                id: t.id,
+                read: t.read,
+                pop: e.target.value,
+                push: t.push
+              })}
               placeholder={'λ\t(pop)'}
               />
             <Input
               value={t.push}
-              onChange={e => savePDATransition(t.id, t.read, t.pop, e.target.value)}
+              onChange={e => savePDATransition({
+                id: t.id,
+                read: t.read,
+                pop: t.pop,
+                push: e.target.value
+              })}
               placeholder={'λ\t(push)'}
             />
           </InputWrapper>)
@@ -95,17 +110,32 @@ const InputTransitionGroup = () => {
         return transitionsList.map((t, i) => <InputWrapper key={i}>
           <Input
             value={t.read}
-            onChange={e => saveTMTransition(t.id, e.target.value, t.write, t.direction)}
+            onChange={e => saveTMTransition({
+              id: t.id,
+              read: e.target.value,
+              write: t.write,
+              direction: t.direction
+            })}
             placeholder={'λ\t(read)'}
           />
           <Input
             value={t.write}
-            onChange={e => saveTMTransition(t.id, t.read, e.target.value, t.direction)}
+            onChange={e => saveTMTransition({
+              id: t.id,
+              read: t.read,
+              write: e.target.value,
+              direction: t.direction
+            })}
             placeholder={'λ\t(write)'}
           />
           <Input
             value={t.direction}
-            onChange={e => saveTMTransition(t.id, t.read, t.write, e.target.value)}
+            onChange={e => saveTMTransition({
+              id: t.id,
+              read: t.read,
+              write: t.write,
+              direction: e.target.value
+            })}
             placeholder={'↔\t(direction)'}
           />
         </InputWrapper>)

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -91,19 +91,37 @@ const InputTransitionGroup = () => {
     setIdList(idList.filter((_, i) => i !== index))
   }
 
-  const handleEnterKey = () => {
-    if (selectedIndex === -1) {
-      saveNewFSATransition()
-    } else {
-      const nextIndex = selectedIndex < transitionsList?.length - 1 ?? -1 ? selectedIndex + 1 : -1
-      const nextInputRef = nextIndex >= 0 ? transitionListRef[nextIndex] : inputRef
-      const ro = nextInputRef as RefObject<HTMLInputElement>
-      setSelectedIndex(nextIndex)
+  const handleIndexDown = () => {
+    const nextIndex = selectedIndex < transitionsList?.length - 1 ?? -1 ? selectedIndex + 1 : -1
+    const nextInputRef = nextIndex >= 0 ? transitionListRef[nextIndex] : inputRef
+    const ro = nextInputRef as RefObject<HTMLInputElement>
+    setSelectedIndex(nextIndex)
+    ro?.current.focus()
+  }
+
+  const handleIndexUp = () => {
+    if (selectedIndex !== 0) {
+      const prevIndex = selectedIndex === -1 ? transitionListRef?.length - 1 ?? 0 : selectedIndex - 1
+      const prevInputRef = transitionListRef[prevIndex]
+      const ro = prevInputRef as RefObject<HTMLInputElement>
+      setSelectedIndex(prevIndex)
       ro?.current.focus()
     }
   }
 
-  const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => e.key === 'Enter' && handleEnterKey()
+  const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
+    switch (e.key){
+      case 'Enter':
+        if (selectedIndex === -1) { saveNewFSATransition() } else { handleIndexDown() }
+        break
+      case 'ArrowDown':
+        handleIndexDown()
+        break
+      case 'ArrowUp':
+        handleIndexUp()
+        break
+    }
+  }
 
   /**
    * Functions for FSAs

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -118,6 +118,7 @@ const InputTransitionGroup = () => {
       onChange={e => setReadValue(e.target.value)}
       onClick={() => setSelectedIndex(-1)}
       onKeyUp={handleKeyUp}
+      onFocus={e => e.target.select()}
       placeholder={'λ (New transition)'}
     />
     <SubmitButton onClick={saveNewFSATransition}>
@@ -150,6 +151,9 @@ const InputTransitionGroup = () => {
         ref={inputRef}
         value={readValue}
         onChange={e => setReadValue(e.target.value)}
+        onClick={() => setSelectedIndex(-1)}
+        onKeyUp={handleKeyUp}
+        onFocus={e => e.target.select()}
         placeholder={'λ\t(read)'}
         />
     </InputSpacingWrapper>
@@ -157,6 +161,9 @@ const InputTransitionGroup = () => {
       <Input
         value={popValue}
         onChange={e => setPopValue(e.target.value)}
+        onClick={() => setSelectedIndex(-1)}
+        onKeyUp={handleKeyUp}
+        onFocus={e => e.target.select()}
         placeholder={'λ\t(pop)'}
         />
     </InputSpacingWrapper>
@@ -164,6 +171,9 @@ const InputTransitionGroup = () => {
       <Input
         value={pushValue}
         onChange={e => setPushValue(e.target.value)}
+        onClick={() => setSelectedIndex(-1)}
+        onKeyUp={handleKeyUp}
+        onFocus={e => e.target.select()}
         placeholder={'λ\t(push)'}
         />
     </InputSpacingWrapper>
@@ -213,6 +223,9 @@ const InputTransitionGroup = () => {
           const r = tmReadWriteValidate(e)
           setReadValue(r)
         }}
+        onClick={() => setSelectedIndex(-1)}
+        onKeyUp={handleKeyUp}
+        onFocus={e => e.target.select()}
         placeholder={'λ\t(read)'}
         />
     </InputSpacingWrapper>
@@ -223,6 +236,9 @@ const InputTransitionGroup = () => {
           const w = tmReadWriteValidate(e)
           setWriteValue(w)
         }}
+        onClick={() => setSelectedIndex(-1)}
+        onKeyUp={handleKeyUp}
+        onFocus={e => e.target.select()}
         placeholder={'λ\t(write)'}
         />
     </InputSpacingWrapper>
@@ -233,6 +249,9 @@ const InputTransitionGroup = () => {
           const d = tmDirectionValidate(e)
           setDirValue(d)
         }}
+        onClick={() => setSelectedIndex(-1)}
+        onKeyUp={handleKeyUp}
+        onFocus={e => e.target.select()}
         placeholder={'↔\t(direction)'}
         />
     </InputSpacingWrapper>
@@ -262,6 +281,7 @@ const InputTransitionGroup = () => {
               }}
               onClick={() => setSelectedIndex(i)}
               onKeyUp={handleKeyUp}
+              onFocus={e => e.target.select()}
               placeholder={'λ'}
           />)}
           <hr/>
@@ -274,6 +294,7 @@ const InputTransitionGroup = () => {
           {transitionsList.map((t, i) => <InputWrapper key={i}>
             <InputSpacingWrapper>
               <Input
+                ref={transitionListRef[i] ?? null}
                 value={t.read}
                 onChange={e => {
                   savePDATransition({
@@ -282,31 +303,47 @@ const InputTransitionGroup = () => {
                     pop: t.pop,
                     push: t.push
                   })
+                  setSelectedIndex(i)
                 }}
+                onClick={() => setSelectedIndex(i)}
+                onKeyUp={handleKeyUp}
+                onFocus={e => e.target.select()}
                 placeholder={'λ'}
                 />
             </InputSpacingWrapper>
             <InputSpacingWrapper>
             <Input
               value={t.pop}
-              onChange={e => savePDATransition({
-                id: t.id,
-                read: t.read,
-                pop: e.target.value,
-                push: t.push
-              })}
+              onChange={e => {
+                savePDATransition({
+                  id: t.id,
+                  read: t.read,
+                  pop: e.target.value,
+                  push: t.push
+                })
+                setSelectedIndex(i)
+              }}
+              onClick={() => setSelectedIndex(i)}
+              onKeyUp={handleKeyUp}
+              onFocus={e => e.target.select()}
               placeholder={'λ'}
               />
             </InputSpacingWrapper>
             <InputSpacingWrapper>
               <Input
                 value={t.push}
-                onChange={e => savePDATransition({
-                  id: t.id,
-                  read: t.read,
-                  pop: t.pop,
-                  push: e.target.value
-                })}
+                onChange={e => {
+                  savePDATransition({
+                    id: t.id,
+                    read: t.read,
+                    pop: t.pop,
+                    push: e.target.value
+                  })
+                  setSelectedIndex(i)
+                }}
+                onClick={() => setSelectedIndex(i)}
+                onKeyUp={handleKeyUp}
+                onFocus={e => e.target.select()}
                 placeholder={'λ'}
                 />
             </InputSpacingWrapper>
@@ -321,6 +358,7 @@ const InputTransitionGroup = () => {
           {transitionsList.map((t, i) => <InputWrapper key={i}>
             <InputSpacingWrapper>
               <Input
+                ref={transitionListRef[i] ?? null}
                 value={t.read}
                 onChange={e => {
                   const r = tmReadWriteValidate(e)
@@ -330,7 +368,11 @@ const InputTransitionGroup = () => {
                     write: t.write,
                     direction: t.direction
                   })
+                  setSelectedIndex(i)
                 }}
+                onClick={() => setSelectedIndex(i)}
+                onKeyUp={handleKeyUp}
+                onFocus={e => e.target.select()}
                 placeholder={'λ\t(read)'}
                 />
             </InputSpacingWrapper>
@@ -345,7 +387,11 @@ const InputTransitionGroup = () => {
                     write: w,
                     direction: t.direction
                   })
+                  setSelectedIndex(i)
                 }}
+                onClick={() => setSelectedIndex(i)}
+                onKeyUp={handleKeyUp}
+                onFocus={e => e.target.select()}
                 placeholder={'λ\t(write)'}
                 />
             </InputSpacingWrapper>
@@ -360,7 +406,11 @@ const InputTransitionGroup = () => {
                     write: t.write,
                     direction: d
                   })
+                  setSelectedIndex(i)
                 }}
+                onClick={() => setSelectedIndex(i)}
+                onKeyUp={handleKeyUp}
+                onFocus={e => e.target.select()}
                 placeholder={'↔\t(direction)'}
                 />
             </InputSpacingWrapper>

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -9,7 +9,7 @@ import {
   useRef,
   useState
 } from 'react'
-import { InputSpacingWrapper } from './inputTransitionGroupStyle'
+import { InputSeparator, InputSpacingWrapper } from './inputTransitionGroupStyle'
 import Button from '/src/components/Button/Button'
 import Input from '/src/components/Input/Input'
 import { InputWrapper, SubmitButton } from '/src/components/InputDialogs/inputDialogsStyle'
@@ -199,6 +199,7 @@ const InputTransitionGroup = () => {
         placeholder={'λ\t(read)'}
         />
     </InputSpacingWrapper>
+    <InputSeparator>,</InputSeparator>
     <InputSpacingWrapper>
       <Input
         value={popValue}
@@ -209,6 +210,7 @@ const InputTransitionGroup = () => {
         placeholder={'λ\t(pop)'}
         />
     </InputSpacingWrapper>
+    <InputSeparator>;</InputSeparator>
     <InputSpacingWrapper>
       <Input
         value={pushValue}
@@ -273,6 +275,7 @@ const InputTransitionGroup = () => {
         placeholder={'λ\t(read)'}
         />
     </InputSpacingWrapper>
+    <InputSeparator>,</InputSeparator>
     <InputSpacingWrapper>
       <Input
         value={writeValue}
@@ -286,6 +289,7 @@ const InputTransitionGroup = () => {
         placeholder={'λ\t(write)'}
         />
     </InputSpacingWrapper>
+    <InputSeparator>;</InputSeparator>
     <InputSpacingWrapper>
       <Input
         value={dirValue}
@@ -372,6 +376,7 @@ const InputTransitionGroup = () => {
                 placeholder={'λ'}
                 />
             </InputSpacingWrapper>
+            <InputSeparator>,</InputSeparator>
             <InputSpacingWrapper>
             <Input
               value={t.pop}
@@ -390,6 +395,7 @@ const InputTransitionGroup = () => {
               placeholder={'λ'}
               />
             </InputSpacingWrapper>
+            <InputSeparator>;</InputSeparator>
             <InputSpacingWrapper>
               <Input
                 value={t.push}
@@ -440,6 +446,7 @@ const InputTransitionGroup = () => {
                 placeholder={'λ'}
                 />
             </InputSpacingWrapper>
+            <InputSeparator>,</InputSeparator>
             <InputSpacingWrapper>
               <Input
                 value={t.write}
@@ -459,6 +466,7 @@ const InputTransitionGroup = () => {
                 placeholder={'λ'}
                 />
             </InputSpacingWrapper>
+            <InputSeparator>;</InputSeparator>
             <InputSpacingWrapper>
               <Input
                 value={t.direction}

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -318,7 +318,9 @@ const InputTransitionGroup = () => {
         break
       case 'TM':
         saveNewTMTransition()
+        break
     }
+    inputRef.current.focus()
   }
 
   /**

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -81,14 +81,12 @@ const InputTransitionGroup = () => {
    */
   const saveFSATransition = ({ id, read }) => {
     editTransition({ id, read })
-    commit()
     retrieveTransitions()
   }
 
   const saveNewFSATransition = () => {
     const newId = createNewTransition()
     editTransition({ id: newId, read: readValue } as FSAAutomataTransition)
-    commit()
     resetInputFields()
   }
 
@@ -108,7 +106,6 @@ const InputTransitionGroup = () => {
    */
   const savePDATransition = ({ id, read, pop, push }) => {
     editTransition({ id, read, pop, push } as PDAAutomataTransition)
-    commit()
     retrieveTransitions()
   }
 
@@ -120,7 +117,6 @@ const InputTransitionGroup = () => {
       pop: popValue,
       push: pushValue
     } as PDAAutomataTransition)
-    commit()
     resetInputFields()
   }
 
@@ -156,7 +152,6 @@ const InputTransitionGroup = () => {
    */
   const saveTMTransition = ({ id, read, write, direction }) => {
     editTransition({ id, read, write, direction: direction || 'R' } as TMAutomataTransition)
-    commit()
     retrieveTransitions()
   }
 
@@ -168,7 +163,6 @@ const InputTransitionGroup = () => {
       write: writeValue,
       direction: dirValue
     } as TMAutomataTransition)
-    commit()
     resetInputFields()
   }
 
@@ -314,6 +308,7 @@ const InputTransitionGroup = () => {
       }
     isOpen={modalOpen}
     actions={<Button onClick={() => {
+      commit()
       setModalOpen(false)
       resetInputFields()
     }}>Done</Button>}

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -508,6 +508,11 @@ const InputTransitionGroup = () => {
         statePrefix + toState + '.'
       }
     isOpen={modalOpen}
+    onClose={() => {
+      commit()
+      setModalOpen(false)
+      resetInputFields()
+    }}
     actions={<Button onClick={() => {
       commit()
       setModalOpen(false)

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -117,7 +117,7 @@ const InputTransitionGroup = () => {
   }
 
   const handleIndexDown = () => {
-    const nextIndex = selectedIndex < transitionsList?.length - 1 ?? -1 ? selectedIndex + 1 : -1
+    const nextIndex = selectedIndex < 0 ? -1 : selectedIndex - 1
     const nextInputRef = nextIndex >= 0 ? transitionListRef[nextIndex] : inputRef
     const ro = nextInputRef as RefObject<HTMLInputElement>
     setSelectedIndex(nextIndex)
@@ -125,8 +125,8 @@ const InputTransitionGroup = () => {
   }
 
   const handleIndexUp = () => {
-    if (selectedIndex !== 0) {
-      const prevIndex = selectedIndex === -1 ? transitionListRef?.length - 1 ?? 0 : selectedIndex - 1
+    if (selectedIndex < transitionListRef?.length - 1) {
+      const prevIndex = selectedIndex === transitionListRef?.length - 1 ?? 0 ? transitionListRef?.length - 1 ?? 0 : selectedIndex + 1
       const prevInputRef = transitionListRef[prevIndex]
       const ro = prevInputRef as RefObject<HTMLInputElement>
       setSelectedIndex(prevIndex)

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -35,12 +35,19 @@ const InputTransitionGroup = () => {
   useEvent('editTransitionGroup', ({ detail: { ids } }) => {
     // Get transitions from store
     const { transitions } = useProjectStore.getState()?.project ?? {}
+    // Do preliminary store updates
     setIdList([...ids])
     const transitionsScope = transitions.filter(t => ids.includes(t.id))
     // All of these should be part of the same transition edge
     setFromState(transitionsScope[0].from)
     setToState(transitionsScope[0].to)
     setTransitionsList(transitionsScope)
+    // Update ID list to include *ALL* transitions on this edge, including unselected
+    // This will run the side effect of re-retrieving the updated id list when done
+    const allIdList = transitions.filter(
+      t => t.from === transitionsScope[0].from && t.to === transitionsScope[0].to
+    ).map(t => t.id)
+    setIdList([...allIdList])
     setModalOpen(true)
   })
 
@@ -49,6 +56,11 @@ const InputTransitionGroup = () => {
     const transitionsScope = transitions.filter(t => idList.includes(t.id))
     setTransitionsList([...transitionsScope])
   }
+
+  // Re-retrieve transitions when the id list changes (i.e. on new transition)
+  useEffect(() => {
+    retrieveTransitions()
+  }, [idList])
 
   const resetInputFields = () => {
     setReadValue('')
@@ -63,11 +75,6 @@ const InputTransitionGroup = () => {
     setIdList([...idList, newId])
     return newId
   }
-
-  // Re-retrieve transitions when the id list changes (i.e. on new transition)
-  useEffect(() => {
-    retrieveTransitions()
-  }, [idList])
 
   /**
    * Functions for FSAs

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -1,4 +1,4 @@
-import { CornerDownLeft } from 'lucide-react'
+import { CornerDownLeft, Cross, X } from 'lucide-react'
 import { ChangeEvent, KeyboardEvent, Ref, RefObject, createRef, useEffect, useRef, useState } from 'react'
 import { InputSpacingWrapper } from './inputTransitionGroupStyle'
 import Button from '/src/components/Button/Button'
@@ -12,6 +12,7 @@ import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, T
 const InputTransitionGroup = () => {
   const inputRef = useRef<HTMLInputElement>()
   const [transitionListRef, setTransitionListRef] = useState<Array<Ref<HTMLInputElement>>>()
+  // selectIndex === -1 is the new transition field, others is the index
   const [selectedIndex, setSelectedIndex] = useState(-1)
 
   const [fromState, setFromState] = useState<number>()
@@ -34,6 +35,7 @@ const InputTransitionGroup = () => {
 
   const editTransition = useProjectStore(s => s.editTransition)
   const createTransition = useProjectStore(s => s.createTransition)
+  const removeTransitions = useProjectStore(s => s.removeTransitions)
   const commit = useProjectStore(s => s.commit)
   // Get data from event dispatch
   useEvent('editTransitionGroup', ({ detail: { ids } }) => {
@@ -81,6 +83,12 @@ const InputTransitionGroup = () => {
     const newId = createTransition({ from: fromState, to: toState })
     setIdList([...idList, newId])
     return newId
+  }
+
+  const deleteTransition = (index: number) => {
+    const delId = idList[index]
+    removeTransitions([delId])
+    setIdList(idList.filter((_, i) => i !== index))
   }
 
   const handleEnterKey = () => {
@@ -273,9 +281,9 @@ const InputTransitionGroup = () => {
       case 'FSA':
         assertType<Array<FSAAutomataTransition>>(transitionsList)
         return <>
-          {transitionsList.map((t, i) => <Input
+          {transitionsList.map((t, i) => <InputWrapper key={i}>
+          <Input
               ref={transitionListRef[i] ?? null}
-              key={i}
               value={t.read}
               onChange={e => {
                 saveFSATransition({ id: t.id, read: e.target.value })
@@ -285,7 +293,11 @@ const InputTransitionGroup = () => {
               onKeyUp={handleKeyUp}
               onFocus={e => e.target.select()}
               placeholder={'λ'}
-          />)}
+          />
+          <SubmitButton onClick={() => deleteTransition(i)}>
+            <X size='18px'/>
+          </SubmitButton>
+          </InputWrapper>)}
           <hr/>
           Add a new transition?
           {blankFSAInput()}
@@ -349,6 +361,9 @@ const InputTransitionGroup = () => {
                 placeholder={'λ'}
                 />
             </InputSpacingWrapper>
+            <SubmitButton onClick={() => deleteTransition(i)}>
+              <X size='18px'/>
+            </SubmitButton>
           </InputWrapper>)}
           <hr/>
           Add a new transition?
@@ -416,6 +431,9 @@ const InputTransitionGroup = () => {
                 placeholder={'↔\t(direction)'}
                 />
             </InputSpacingWrapper>
+            <SubmitButton onClick={() => deleteTransition(i)}>
+              <X size='18px'/>
+            </SubmitButton>
           </InputWrapper>
           )}
           <hr/>

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -1,5 +1,5 @@
 import { CornerDownLeft } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { ChangeEvent, Dispatch, SetStateAction, useEffect, useState } from 'react'
 import { InputSpacingWrapper } from './inputTransitionGroupStyle'
 import Button from '/src/components/Button/Button'
 import Input from '/src/components/Input/Input'
@@ -7,7 +7,7 @@ import { InputWrapper, SubmitButton } from '/src/components/InputDialogs/inputDi
 import Modal from '/src/components/Modal/Modal'
 import { useEvent } from '/src/hooks'
 import { useProjectStore } from '/src/stores'
-import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, TMAutomataTransition, assertType } from '/src/types/ProjectTypes'
+import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, TMAutomataTransition, TMDirection, assertType } from '/src/types/ProjectTypes'
 
 const InputTransitionGroup = () => {
   const [fromState, setFromState] = useState<number>()
@@ -166,25 +166,47 @@ const InputTransitionGroup = () => {
     resetInputFields()
   }
 
+  /** TMs operate with the assumption of reading and writing one character */
+  const tmReadWriteValidate = (e: ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value.toString()
+    return input[input.length - 1] ?? ''
+  }
+
+  /** Copied over from InputDialogs handleDirectionIn @see InputDialogs */
+  const tmDirectionValidate = (e: ChangeEvent<HTMLInputElement>) => {
+    const input = e.target.value.toString().match(/[rls]|^$/gi)
+    const value = input[input.length - 1].toUpperCase()
+    return value as TMDirection
+  }
+
   const blankTMInput = () => <InputWrapper>
     <InputSpacingWrapper>
       <Input
         value={readValue}
-        onChange={e => setReadValue(e.target.value)}
+        onChange={e => {
+          const r = tmReadWriteValidate(e)
+          setReadValue(r)
+        }}
         placeholder={'λ\t(read)'}
         />
     </InputSpacingWrapper>
     <InputSpacingWrapper>
       <Input
         value={writeValue}
-        onChange={e => setWriteValue(e.target.value)}
+        onChange={e => {
+          const w = tmReadWriteValidate(e)
+          setWriteValue(w)
+        }}
         placeholder={'λ\t(write)'}
         />
     </InputSpacingWrapper>
     <InputSpacingWrapper>
       <Input
         value={dirValue}
-        onChange={e => setDirValue(e.target.value)}
+        onChange={e => {
+          const d = tmDirectionValidate(e)
+          setDirValue(d)
+        }}
         placeholder={'↔\t(direction)'}
         />
     </InputSpacingWrapper>
@@ -211,6 +233,7 @@ const InputTransitionGroup = () => {
               placeholder={'λ'}
           />)}
           <hr/>
+          Add a new transition?
           {blankFSAInput()}
         </>
       case 'PDA':
@@ -220,12 +243,14 @@ const InputTransitionGroup = () => {
             <InputSpacingWrapper>
               <Input
                 value={t.read}
-                onChange={e => savePDATransition({
-                  id: t.id,
-                  read: e.target.value,
-                  pop: t.pop,
-                  push: t.push
-                })}
+                onChange={e => {
+                  savePDATransition({
+                    id: t.id,
+                    read: e.target.value,
+                    pop: t.pop,
+                    push: t.push
+                  })
+                }}
                 placeholder={'λ'}
                 />
             </InputSpacingWrapper>
@@ -255,6 +280,7 @@ const InputTransitionGroup = () => {
             </InputSpacingWrapper>
           </InputWrapper>)}
           <hr/>
+          Add a new transition?
           {blankPDAInput()}
         </>
       case 'TM':
@@ -263,37 +289,47 @@ const InputTransitionGroup = () => {
           {transitionsList.map((t, i) => <InputWrapper key={i}>
             <Input
               value={t.read}
-              onChange={e => saveTMTransition({
-                id: t.id,
-                read: e.target.value,
-                write: t.write,
-                direction: t.direction
-              })}
+              onChange={e => {
+                const r = tmReadWriteValidate(e)
+                saveTMTransition({
+                  id: t.id,
+                  read: r,
+                  write: t.write,
+                  direction: t.direction
+                })
+              }}
               placeholder={'λ\t(read)'}
             />
             <Input
               value={t.write}
-              onChange={e => saveTMTransition({
-                id: t.id,
-                read: t.read,
-                write: e.target.value,
-                direction: t.direction
-              })}
+              onChange={e => {
+                const w = tmReadWriteValidate(e)
+                saveTMTransition({
+                  id: t.id,
+                  read: t.read,
+                  write: w,
+                  direction: t.direction
+                })
+              }}
               placeholder={'λ\t(write)'}
             />
             <Input
               value={t.direction}
-              onChange={e => saveTMTransition({
-                id: t.id,
-                read: t.read,
-                write: t.write,
-                direction: e.target.value
-              })}
+              onChange={e => {
+                const d = tmDirectionValidate(e)
+                saveTMTransition({
+                  id: t.id,
+                  read: t.read,
+                  write: t.write,
+                  direction: d
+                })
+              }}
               placeholder={'↔\t(direction)'}
             />
           </InputWrapper>
           )}
           <hr/>
+          Add a new transition?
           {blankTMInput()}
         </>
     }

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -2,10 +2,10 @@ import { useState } from 'react'
 import { useEvent } from '/src/hooks'
 import { useProjectStore } from '/src/stores'
 import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, TMAutomataTransition, assertType } from '/src/types/ProjectTypes'
-import Modal from '../Modal/Modal'
-import Button from '../Button/Button'
-import Input from '../Input/Input'
-import { InputWrapper } from '../InputDialogs/inputDialogsStyle'
+import Modal from '/src/components/Modal/Modal'
+import Button from '/src/components/Button/Button'
+import Input from '/src/components/Input/Input'
+import { InputWrapper } from '/src/components/InputDialogs/inputDialogsStyle'
 
 const InputTransitionGroup = () => {
   const [fromState, setFromState] = useState<number>()
@@ -16,6 +16,9 @@ const InputTransitionGroup = () => {
 
   const statePrefix = useProjectStore(s => s.project.config.statePrefix)
   const projectType = useProjectStore(s => s.project.config.type)
+
+  const editTransition = useProjectStore(s => s.editTransition)
+  const commit = useProjectStore(s => s.commit)
   // Get data from event dispatch
   useEvent('editTransitionGroup', ({ detail: { ids } }) => {
     // Get transitions from store
@@ -27,6 +30,20 @@ const InputTransitionGroup = () => {
     setTransitionsList(transitionsScope)
     setModalOpen(true)
   })
+
+  const saveFSATransition = (id, read) => {
+    editTransition({ id, read })
+    commit()
+  }
+
+  const savePDATransition = (id, read, pop, push) => {
+    editTransition({ id, read, pop, push } as PDAAutomataTransition)
+    commit()
+  }
+
+  const saveTMTransition = (id, read, write, direction) => {
+    editTransition({ id, read, write, direction: direction || 'R' } as TMAutomataTransition)
+  }
 
   if (!transitionsList) return null
 
@@ -67,7 +84,7 @@ const InputTransitionGroup = () => {
     isOpen={modalOpen}
     actions={<Button onClick={() => setModalOpen(false)}>Done</Button>}
   >
-    <div>{contents()}</div>
+    {contents()}
   </Modal>
 }
 

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -1,5 +1,14 @@
-import { CornerDownLeft, Cross, X } from 'lucide-react'
-import { ChangeEvent, KeyboardEvent, Ref, RefObject, createRef, useEffect, useRef, useState } from 'react'
+import { CornerDownLeft, X } from 'lucide-react'
+import {
+  ChangeEvent,
+  KeyboardEvent,
+  Ref,
+  RefObject,
+  createRef,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 import { InputSpacingWrapper } from './inputTransitionGroupStyle'
 import Button from '/src/components/Button/Button'
 import Input from '/src/components/Input/Input'
@@ -7,7 +16,14 @@ import { InputWrapper, SubmitButton } from '/src/components/InputDialogs/inputDi
 import Modal from '/src/components/Modal/Modal'
 import { useEvent } from '/src/hooks'
 import { useProjectStore } from '/src/stores'
-import { BaseAutomataTransition, FSAAutomataTransition, PDAAutomataTransition, TMAutomataTransition, TMDirection, assertType } from '/src/types/ProjectTypes'
+import {
+  BaseAutomataTransition,
+  FSAAutomataTransition,
+  PDAAutomataTransition,
+  TMAutomataTransition,
+  TMDirection,
+  assertType
+} from '/src/types/ProjectTypes'
 
 const InputTransitionGroup = () => {
   const inputRef = useRef<HTMLInputElement>()
@@ -110,9 +126,9 @@ const InputTransitionGroup = () => {
   }
 
   const handleKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
-    switch (e.key){
+    switch (e.key) {
       case 'Enter':
-        if (selectedIndex === -1) { saveNewFSATransition() } else { handleIndexDown() }
+        if (selectedIndex === -1) { saveNewTransition() } else { handleIndexDown() }
         break
       case 'ArrowDown':
         handleIndexDown()
@@ -147,7 +163,7 @@ const InputTransitionGroup = () => {
       onFocus={e => e.target.select()}
       placeholder={'λ (New transition)'}
     />
-    <SubmitButton onClick={saveNewFSATransition}>
+    <SubmitButton onClick={saveNewTransition}>
       <CornerDownLeft size='18px' />
     </SubmitButton>
   </InputWrapper>
@@ -203,7 +219,7 @@ const InputTransitionGroup = () => {
         placeholder={'λ\t(push)'}
         />
     </InputSpacingWrapper>
-    <SubmitButton onClick={saveNewPDATransition}>
+    <SubmitButton onClick={saveNewTransition}>
       <CornerDownLeft size='18px' />
     </SubmitButton>
   </InputWrapper>
@@ -222,7 +238,7 @@ const InputTransitionGroup = () => {
       id: newId,
       read: readValue,
       write: writeValue,
-      direction: dirValue
+      direction: dirValue === '' ? 'R' : dirValue
     } as TMAutomataTransition)
     resetInputFields()
   }
@@ -280,13 +296,26 @@ const InputTransitionGroup = () => {
         onClick={() => setSelectedIndex(-1)}
         onKeyUp={handleKeyUp}
         onFocus={e => e.target.select()}
-        placeholder={'↔\t(direction)'}
+        placeholder={'R\t(direction)'}
         />
     </InputSpacingWrapper>
-    <SubmitButton onClick={saveNewTMTransition}>
+    <SubmitButton onClick={saveNewTransition}>
       <CornerDownLeft size='18px' />
     </SubmitButton>
   </InputWrapper>
+
+  const saveNewTransition = () => {
+    switch (projectType) {
+      case 'FSA':
+        saveNewFSATransition()
+        break
+      case 'PDA':
+        saveNewPDATransition()
+        break
+      case 'TM':
+        saveNewTMTransition()
+    }
+  }
 
   /**
    * Modal contents
@@ -408,7 +437,7 @@ const InputTransitionGroup = () => {
                 onClick={() => setSelectedIndex(i)}
                 onKeyUp={handleKeyUp}
                 onFocus={e => e.target.select()}
-                placeholder={'λ\t(read)'}
+                placeholder={'λ'}
                 />
             </InputSpacingWrapper>
             <InputSpacingWrapper>
@@ -427,7 +456,7 @@ const InputTransitionGroup = () => {
                 onClick={() => setSelectedIndex(i)}
                 onKeyUp={handleKeyUp}
                 onFocus={e => e.target.select()}
-                placeholder={'λ\t(write)'}
+                placeholder={'λ'}
                 />
             </InputSpacingWrapper>
             <InputSpacingWrapper>
@@ -446,7 +475,7 @@ const InputTransitionGroup = () => {
                 onClick={() => setSelectedIndex(i)}
                 onKeyUp={handleKeyUp}
                 onFocus={e => e.target.select()}
-                placeholder={'↔\t(direction)'}
+                placeholder={'↔'}
                 />
             </InputSpacingWrapper>
             <SubmitButton onClick={() => deleteTransition(i)}>

--- a/frontend/src/components/InputTransitionGroup/inputTransitionGroupStyle.ts
+++ b/frontend/src/components/InputTransitionGroup/inputTransitionGroupStyle.ts
@@ -7,3 +7,7 @@ import { styled } from 'goober'
 export const InputSpacingWrapper = styled('span')`
   margin: .15em .6em .05em .6em;
 `
+
+export const InputSeparator = styled('span')`
+  font-weight: bold;
+`

--- a/frontend/src/components/InputTransitionGroup/inputTransitionGroupStyle.ts
+++ b/frontend/src/components/InputTransitionGroup/inputTransitionGroupStyle.ts
@@ -1,0 +1,9 @@
+import { styled } from 'goober'
+
+/**
+ * Since it's pretty hard to edit the input directly without recreating it,
+ * some padding would make it a bit nicer
+ */
+export const InputSpacingWrapper = styled('span')`
+  margin: .15em .6em .05em .6em;
+`

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -171,6 +171,9 @@ const Transition = ({
   }
 
   // Callbacks for the edge
+  const handleEdgeMouseUp = (e: MouseEvent) => {
+    dispatchCustomEvent('edge:mouseup', { originalEvent: e, transitions })
+  }
 
   const handleEdgeMouseDown = (e: MouseEvent) =>
     dispatchCustomEvent('edge:mousedown', { originalEvent: e, transitions })
@@ -211,6 +214,7 @@ const Transition = ({
       key={`${pathID}-selection`}
       stroke='transparent'
       fill='none'
+      onMouseUp={handleEdgeMouseUp}
       onMouseDown={handleEdgeMouseDown}
       onDoubleClick={handleEdgeDoubleClick}
       strokeWidth={20}

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -175,8 +175,11 @@ const Transition = ({
   const handleEdgeMouseDown = (e: MouseEvent) =>
     dispatchCustomEvent('edge:mousedown', { originalEvent: e, transitions })
 
-  const handleEdgeDoubleClick = (e: MouseEvent) =>
+  const handleEdgeDoubleClick = (e: MouseEvent) => {
+    // Edit only first transition on dbl-click
+    dispatchCustomEvent('editTransition', { id: transitions[0].id })
     dispatchCustomEvent('edge:dblclick', { originalEvent: e, transitions })
+  }
 
   // Calculate text offset. We want transitions that curve under to extend downwards and over/straight to extend
   // upwards.

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as Toolbar } from './Toolbar/Toolbar'
 export { default as Sidepanel } from './Sidepanel/Sidepanel'
 export { default as ContextMenus } from './ContextMenus/ContextMenus'
 export { default as InputDialogs } from './InputDialogs/InputDialogs'
+export { default as InputTransitionGroup } from './InputTransitionGroup/InputTransitionGroup'
 export { default as EditorPanel } from './EditorPanel/EditorPanel'
 export { default as BottomPanel } from './BottomPanel/BottomPanel'
 

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -336,6 +336,13 @@ const useActions = (registerHotkeys = false) => {
         window.setTimeout(() => dispatchCustomEvent('editTransition', { id: selectedTransition }), 100)
       }
     },
+    EDIT_TRANSITIONS_GROUP: {
+      handler: () => {
+        const selectedTransitions = useSelectionStore.getState().selectedTransitions
+        if (selectedTransitions === undefined) return
+        window.setTimeout(() => dispatchCustomEvent('editTransitionGroup', { ids: selectedTransitions }), 100)
+      }
+    },
     FLIP_TRANSITION: {
       handler: () => {
         const selectedTransitions = useSelectionStore.getState().selectedTransitions

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -222,6 +222,21 @@ const useActions = (registerHotkeys = false) => {
         }
       }
     },
+    DELETE_EDGE: {
+      disabled: () => useSelectionStore.getState()?.selectedTransitions?.length === 0,
+      handler: () => {
+        const tIds = selectedTransitionsIds
+        const { transitions } = useProjectStore.getState()?.project ?? {}
+        const oneTransitionOnEdge = transitions.find(t => tIds.includes(t.id))
+        // Expand IDs to include ALL on the edge
+        const allTransitionIdsOnEdge = transitions.filter(
+          t => t.from === oneTransitionOnEdge.from && t.to === oneTransitionOnEdge.to
+        ).map(t => t.id)
+        removeTransitions(allTransitionIdsOnEdge)
+        selectNone()
+        commit()
+      }
+    },
     ZOOM_IN: {
       hotkeys: [{ key: '=', meta: true }],
       handler: () => zoomViewTo(useViewStore.getState().scale - 0.1)

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -337,6 +337,7 @@ const useActions = (registerHotkeys = false) => {
       }
     },
     EDIT_TRANSITIONS_GROUP: {
+      disabled: () => useSelectionStore.getState()?.selectedTransitions?.length === 0,
       handler: () => {
         const selectedTransitions = useSelectionStore.getState().selectedTransitions
         if (selectedTransitions === undefined) return

--- a/frontend/src/hooks/useContextMenus.ts
+++ b/frontend/src/hooks/useContextMenus.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import useEvent, {
   CommentEventData,
   CustomEvents,
+  EdgeEventData,
   StateEventData,
   SVGMouseEventData,
   TransitionEventData
@@ -9,7 +10,7 @@ import useEvent, {
 import { dispatchCustomEvent } from '/src/util/events'
 
 const useContextMenus = () => {
-  type EventData = CustomEvent<StateEventData | SVGMouseEventData | TransitionEventData | CommentEventData>
+  type EventData = CustomEvent<StateEventData | SVGMouseEventData | TransitionEventData | CommentEventData | EdgeEventData>
   const showContext = (name: keyof CustomEvents) => useCallback((e: EventData) => {
     if (e.detail.originalEvent.button === 2) {
       dispatchCustomEvent(name, {
@@ -24,6 +25,7 @@ const useContextMenus = () => {
   useEvent('state:mouseup', showContext('ctx:state'))
   useEvent('transition:mouseup', showContext('ctx:transition'))
   useEvent('comment:mouseup', showContext('ctx:comment'))
+  useEvent('edge:mouseup', showContext('ctx:edge'))
 }
 
 export default useContextMenus

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -17,7 +17,7 @@ export type CommentEventData = {originalEvent: MouseEvent, comment: {id: number,
  * Contains information about the click along with the transition that was clicked
  */
 export type TransitionEventData = {originalEvent: MouseEvent, transition: PositionedTransition}
-type EdgeEventData = {originalEvent: MouseEvent, transitions: PositionedTransition[]}
+export type EdgeEventData = {originalEvent: MouseEvent, transitions: PositionedTransition[]}
 /**
  * Mapping of events to what data the event accepts.
  * If making a custom event just add it here first

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -44,10 +44,14 @@ export interface CustomEvents {
   'transition:mouseup': TransitionEventData,
   'transition:mousedown': TransitionEventData,
   'transition:dblclick': TransitionEventData,
+  /**
+   * Context menu events
+   */
   'ctx:svg': Coordinate,
   'ctx:state': Coordinate,
   'ctx:transition': Coordinate,
   'ctx:comment': Coordinate,
+  'ctx:edge': Coordinate,
   'bottomPanel:open': { panel: string },
   'bottomPanel:close': null,
   'comment:mousedown': CommentEventData,
@@ -58,6 +62,7 @@ export interface CustomEvents {
    * all the transitions that use that edge
    */
   'edge:mousedown': EdgeEventData,
+  'edge:mouseup': EdgeEventData,
   'edge:dblclick': EdgeEventData,
   'showWarning': string
 }

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -29,6 +29,7 @@ export interface CustomEvents {
   'editStateLabel': {id: number},
   'modal:preferences': null,
   'exportImage': {type: string, clipboard?: boolean} | null,
+  'editTransitionGroup': {ids: Array<number>},
   /**
    * Event to open a side panel.
    * @see SidePanelKey for available panels


### PR DESCRIPTION
Closes #398.

I was wondering what actions right-clicking an edge would give since clicking on a transition and clicking on an edge has slightly different meanings. I decided on a mass dialog box containing all transitions on the edge. This means even if only 3/6 transitions were selected, the dialog will display the full 6 transitions in the dialog, as the "edge" should include all these transitions.

![20230814-182058_firefoxDubwq87K_540x305](https://github.com/automatarium/automatarium/assets/82514325/ea01e0a8-6462-4247-b744-0e11e37adc83)

![20230814-182106_firefoxVFZ8x8ya_1094x667](https://github.com/automatarium/automatarium/assets/82514325/187b6923-43d2-4179-af51-850c3fbd1fd6)

Editing any of the inputs in the dialog will be updated in the project state, as well as adding new transitions, so this also serves as one of the ways to add many transitions quicker than dragging each one.

On the undo history: I have made it commit when the dialog is closed, so undoing will undo the entire edit from this dialog as opposed to undoing every single change in the dialogs. This was done to not clog up the undo history but I'm not 100% sure which is better from a usability perspective.

Other notes:
- Up/down arrow keys to move up and down the list
- Enter on the transition list will move focus down
- Enter on the new transition row will create a new transition
- The X on each row will delete the transition

Future todos:
- There are a lot of similarities to InputDialogs, refactoring would be nice
- TM input is validated but it may not be clear what the rules are to the user (single character, [LSR])
- Make look nicer?