### PR TITLE
Using comment tool on non canvas objects

### DIFF
--- a/frontend/src/hooks/useCommentCreation.ts
+++ b/frontend/src/hooks/useCommentCreation.ts
@@ -1,12 +1,15 @@
-import { useEvent } from '/src/hooks'
-import { dispatchCustomEvent } from '/src/util/events'
-import { useToolStore } from '/src/stores'
 import { useCallback } from 'react'
+import { useEvent } from '/src/hooks'
+import { useToolStore } from '/src/stores'
+import { dispatchCustomEvent } from '/src/util/events'
 
 const useCommentCreation = () => {
   const tool = useToolStore(s => s.tool)
 
-  const handleCommentMouseUp = useCallback((e: { detail: { originalEvent: { button: number; clientX: number; clientY: number } } }) => {
+  // Only require a slice of the event in the type else we get the long list of type ors
+  type CommentToolData = { detail: { originalEvent: { button: number; clientX: number; clientY: number } } }
+
+  const handleCommentMouseUp = useCallback((e: CommentToolData) => {
     if (tool === 'comment' && e.detail.originalEvent.button === 0) {
       window.setTimeout(() => dispatchCustomEvent('editComment', { x: e.detail.originalEvent.clientX, y: e.detail.originalEvent.clientY }), 100)
     }

--- a/frontend/src/hooks/useCommentCreation.ts
+++ b/frontend/src/hooks/useCommentCreation.ts
@@ -1,15 +1,22 @@
 import { useEvent } from '/src/hooks'
 import { dispatchCustomEvent } from '/src/util/events'
 import { useToolStore } from '/src/stores'
+import { useCallback } from 'react'
 
 const useCommentCreation = () => {
   const tool = useToolStore(s => s.tool)
 
-  useEvent('svg:mouseup', e => {
+  const handleCommentMouseUp = useCallback((e) => {
     if (tool === 'comment' && e.detail.didTargetSVG && e.detail.originalEvent.button === 0) {
       window.setTimeout(() => dispatchCustomEvent('editComment', { x: e.detail.originalEvent.clientX, y: e.detail.originalEvent.clientY }), 100)
     }
   }, [tool])
+
+  useEvent('svg:mouseup', handleCommentMouseUp)
+  useEvent('state:mouseup', handleCommentMouseUp)
+  useEvent('transition:mouseup', handleCommentMouseUp)
+  useEvent('comment:mouseup', handleCommentMouseUp)
+  useEvent('edge:mouseup', handleCommentMouseUp)
 }
 
 export default useCommentCreation

--- a/frontend/src/hooks/useCommentCreation.ts
+++ b/frontend/src/hooks/useCommentCreation.ts
@@ -6,8 +6,8 @@ import { useCallback } from 'react'
 const useCommentCreation = () => {
   const tool = useToolStore(s => s.tool)
 
-  const handleCommentMouseUp = useCallback((e) => {
-    if (tool === 'comment' && e.detail.didTargetSVG && e.detail.originalEvent.button === 0) {
+  const handleCommentMouseUp = useCallback((e: { detail: { originalEvent: { button: number; clientX: number; clientY: number } } }) => {
+    if (tool === 'comment' && e.detail.originalEvent.button === 0) {
       window.setTimeout(() => dispatchCustomEvent('editComment', { x: e.detail.originalEvent.clientX, y: e.detail.originalEvent.clientY }), 100)
     }
   }, [tool])


### PR DESCRIPTION
Closes #245.

Looked through the issue tracker and thought this was a quick fix.

- Added listeners on the other objects
- Removed the hit SVG boolean from the mouse event check

![20230822-205150_firefoxtAxcA5kt_632x259](https://github.com/automatarium/automatarium/assets/82514325/70ec0727-4cd3-4f36-b664-654e9efac5ad)
