### PR TITLE
Fix stepping lab functionality issues and appearance

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lucide-react'
 
 import { graphStepper, Node, State } from '@automatarium/simulation'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { FSAProjectGraph, PDAProjectGraph } from '/src/types/ProjectTypes'
 
 // The initial states and project store calls, along with the display of the current input trace,

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -1,5 +1,5 @@
 import { Wrapper, ButtonRow } from './steppingLabStyle'
-import { SectionLabel, Input, Button} from '/src/components'
+import { SectionLabel, Input, Button } from '/src/components'
 import { useProjectStore, useSteppingStore } from '/src/stores'
 import {
   SkipBack,

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -62,7 +62,12 @@ const SteppingLab = () => {
           <Button
             icon={<ChevronRight size={25} />}
             disabled={noStepper}
-            onClick={() => handleStep(stepper.forward())}
+            onClick={() => {
+              const frontier = stepper.forward()
+              if (frontier.length > 0) {
+                handleStep(frontier)
+              }
+            }}
           />
         </ButtonRow>
         <ButtonRow>

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -1,5 +1,5 @@
 import { Wrapper, ButtonRow } from './steppingLabStyle'
-import { SectionLabel, Input, Button } from '/src/components'
+import { SectionLabel, Input, Button} from '/src/components'
 import { useProjectStore, useSteppingStore } from '/src/stores'
 import {
   SkipBack,
@@ -19,7 +19,6 @@ import { FSAProjectGraph, PDAProjectGraph } from '/src/types/ProjectTypes'
 // Switch component. For demonstrative purposes, I've made this a separate component for now, which
 // means there's some repetition.
 const SteppingLab = () => {
-  const [, setFrontier] = useState([])
   const traceInput = useProjectStore(s => s.project.tests.single)
   const setTraceInput = useProjectStore(s => s.setSingleTest)
   const setSteppedStates = useSteppingStore(s => s.setSteppedStates)
@@ -33,7 +32,6 @@ const SteppingLab = () => {
   }, [graph, traceInput])
 
   const handleStep = <S extends State>(newFrontier: Node<S>[]) => {
-    setFrontier(newFrontier)
     setSteppedStates(newFrontier)
   }
 

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -36,6 +36,7 @@ const SteppingLab = () => {
   }
 
   const noStepper = stepper === null && false
+
   return (
     <>
       <SectionLabel>Trace</SectionLabel>

--- a/frontend/src/components/Sidepanel/Sidepanel.tsx
+++ b/frontend/src/components/Sidepanel/Sidepanel.tsx
@@ -9,7 +9,7 @@ import { TestingLab, SteppingLab, Info, Options, Templates } from './Panels'
 import { SidebarButton } from '/src/components/Sidebar/Sidebar'
 import { stopTemplateInsert } from './Panels/Templates/Templates'
 
-import { useTemplateStore, useToolStore, useProjectStore } from '/src/stores'
+import { useTemplateStore, useToolStore, useSteppingStore, useProjectStore } from '/src/stores'
 
 import { dispatchCustomEvent } from '/src/util/events'
 
@@ -57,6 +57,7 @@ const Sidepanel = () => {
   const [activePanel, setActivePanel] = useState<PanelItem>()
   const setTemplate = useTemplateStore(s => s.setTemplate)
   const setTool = useToolStore(s => s.setTool)
+  const setSteppedStates = useSteppingStore(s => s.setSteppedStates)
 
   const projectType = useProjectStore(s => s.project.config.type)
 
@@ -73,6 +74,12 @@ const Sidepanel = () => {
       dispatchCustomEvent('bottomPanel:open', { panel: 'tmTape' })
     } else {
       dispatchCustomEvent('bottomPanel:close', null)
+    }
+  }, [activePanel])
+
+  useEffect(() => {
+    if (activePanel?.value !== 'step') {
+      setSteppedStates([])
     }
   }, [activePanel])
 

--- a/frontend/src/components/Sidepanel/Sidepanel.tsx
+++ b/frontend/src/components/Sidepanel/Sidepanel.tsx
@@ -77,6 +77,7 @@ const Sidepanel = () => {
     }
   }, [activePanel])
 
+  // Clear the stepped states if the stepping lab is no longer in use
   useEffect(() => {
     if (activePanel?.value !== 'step') {
       setSteppedStates([])

--- a/frontend/src/components/StateCircle/stateCircleStyle.ts
+++ b/frontend/src/components/StateCircle/stateCircleStyle.ts
@@ -6,7 +6,7 @@ export const circleStyles = {
 }
 
 export const stepGlowStyle = {
-  filter: 'drop-shadow(0px 0px 10px var(--primary)'
+  filter: 'drop-shadow(0px 0px 15px var(--primary)) drop-shadow(0px 0px 20px var(--primary))'
 }
 
 export const circleSelectedClass = css`


### PR DESCRIPTION
Closes #413 and #414 

Changes:

- Removed the usage of setFrontier to avoid unwanted React state refreshes that were causing stepped states to reload
- Removed appearance of the glow circle when the Stepping Lab is not the active panel
- Increased the glow circle's intensity and radius to enhance visibility
- Removed ability to forward step when stepper returns non-empty frontier

Possible future enhancements:

- Disable buttons when movement is not possible
- Provide a visual indicator for the character being used in the traversal
- Add an alert or visual cue when the trace input is not accepted by the machine