### PR TITLE
Add enhancements/fixes to Stepping Lab

### DIFF
--- a/frontend/src/components/Menubar/menus.ts
+++ b/frontend/src/components/Menubar/menus.ts
@@ -145,6 +145,10 @@ const menus: ContextItems = [
         action: 'TESTING_LAB'
       },
       {
+        label: 'Stepping lab',
+        action: 'STEPPING_LAB'
+      },
+      {
         label: 'File info',
         action: 'FILE_INFO'
       },

--- a/frontend/src/components/PDAStackVisualiser/stackVisualiser.tsx
+++ b/frontend/src/components/PDAStackVisualiser/stackVisualiser.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { useEvent } from '/src/hooks'
 import { useProjectStore, usePDAVisualiserStore, useTMSimResultStore } from '/src/stores'
 import './stackVisualiser.css'
 
@@ -34,8 +35,12 @@ const PDAStackVisualiser = () => {
       })
   }
 
+  useEvent('stackVisualiser:toggle', e => {
+    setShowStackTab(e.detail.state)
+  })
+
   return (
-    projectType === 'PDA' && (
+    projectType === 'PDA' && showStackTab && (
       <div className="content-container">
         {/* =========== Title and Tab button =========== */}
         Display Stack{' '}

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react'
 
 import { graphStepper, Node, State } from '@automatarium/simulation'
-import { useMemo } from 'react'
+import { useMemo, useEffect } from 'react'
 import { FSAProjectGraph, PDAProjectGraph } from '/src/types/ProjectTypes'
 
 // The initial states and project store calls, along with the display of the current input trace,
@@ -31,6 +31,11 @@ const SteppingLab = () => {
   const handleStep = <S extends State>(newFrontier: Node<S>[]) => {
     setSteppedStates(newFrontier)
   }
+
+  useEffect(() => {
+    // Upon component mount, initialise the stepper to highlight the initial state
+    handleStep(stepper.reset());
+  }, []);
 
   const noStepper = stepper === null && false
 

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -30,38 +30,36 @@ const SteppingLab = () => {
     return graphStepper(graph as FSAProjectGraph | PDAProjectGraph, traceInput)
   }, [graph, traceInput])
 
-
   const handleStep = (stepType: StepType) => {
-    if (!stepper) return;
+    if (!stepper) return
 
-    let frontier: Node<State>[] = [];
+    let frontier: Node<State>[] = []
 
     switch (stepType) {
       case 'Forward':
-        frontier = stepper.forward();
-        break;
+        frontier = stepper.forward()
+        break
       case 'Backward':
-        frontier = stepper.backward();
-        break;
+        frontier = stepper.backward()
+        break
       case 'Reset':
-        frontier = stepper.reset();
-        break;
+        frontier = stepper.reset()
+        break
       default:
-        break;
+        break
     }
 
     if (frontier && frontier.length > 0) {
-      setSteppedStates(frontier);
+      setSteppedStates(frontier)
     }
   }
 
   useEffect(() => {
     // Upon component mount, initialise the stepper to highlight the initial state
     if (stepper !== null) {
-      handleStep('Reset');
+      handleStep('Reset')
     }
-  }, []);
-
+  }, [])
 
   const noStepper = stepper === null && false
 

--- a/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/SteppingLab/SteppingLab.tsx
@@ -8,7 +8,7 @@ import {
 } from 'lucide-react'
 
 import { graphStepper } from '@automatarium/simulation'
-import { useMemo, useEffect, useState } from 'react'
+import { useMemo, useEffect } from 'react'
 import { FSAProjectGraph, PDAProjectGraph, TMProjectGraph } from '/src/types/ProjectTypes'
 
 type StepType = 'Forward' | 'Backward' | 'Reset'
@@ -24,19 +24,11 @@ const SteppingLab = () => {
 
   const graph = useProjectStore(s => s.getGraph())
 
-  const [canMoveForward, setCanMoveForward] = useState(true)
-  const [canMoveBackward, setCanMoveBackward] = useState(true)
-
   const stepper = useMemo(() => {
     // Graph stepper for PDA currently requires changes to BFS stack logic
     // to handle non-determinism so branching stops on the first rejected transition.
     return graphStepper(graph as FSAProjectGraph | PDAProjectGraph | TMProjectGraph, traceInput)
   }, [graph, traceInput])
-
-  const checkPossibleSteps = () => {
-    setCanMoveForward(stepper.canMoveForward())
-    setCanMoveBackward(stepper.canMoveBackward())
-  }
 
   const handleStep = (stepType: StepType) => {
     let frontier = []
@@ -58,7 +50,6 @@ const SteppingLab = () => {
       if (frontier && frontier.length > 0) {
         setSteppedStates(frontier)
       }
-      checkPossibleSteps()
     }
   }
 
@@ -84,18 +75,22 @@ const SteppingLab = () => {
         <ButtonRow>
           <Button
             icon={<SkipBack size={23} />}
-            disabled={noStepper || !canMoveBackward}
+            disabled={noStepper}
             onClick={() => handleStep('Reset')}
           />
           <Button
             icon={<ChevronLeft size={25} />}
-            disabled={noStepper || !canMoveBackward}
+            disabled={noStepper}
             onClick={() => handleStep('Backward')}
           />
           <Button
             icon={<ChevronRight size={25} />}
-            disabled={noStepper || !canMoveForward}
-            onClick={() => handleStep('Forward')}
+            disabled={noStepper}
+            onClick={() => {
+              if (stepper.canMoveForward()) {
+                handleStep('Forward')
+              }
+            }}
           />
         </ButtonRow>
       </Wrapper>

--- a/frontend/src/components/Sidepanel/Panels/index.ts
+++ b/frontend/src/components/Sidepanel/Panels/index.ts
@@ -1,4 +1,4 @@
-export type SidePanelKey = 'test' | 'about' | 'options'
+export type SidePanelKey = 'test' | 'step' | 'about' | 'options'
 
 export { default as TestingLab } from './TestingLab/TestingLab'
 export { default as SteppingLab } from './SteppingLab/SteppingLab'

--- a/frontend/src/components/Sidepanel/Sidepanel.tsx
+++ b/frontend/src/components/Sidepanel/Sidepanel.tsx
@@ -84,6 +84,15 @@ const Sidepanel = () => {
     }
   }, [activePanel])
 
+  // Show the stack visualiser only if the Testing Lab is currently in use
+  useEffect(() => {
+    if (projectType === 'PDA' && activePanel?.value === 'test') {
+      dispatchCustomEvent('stackVisualiser:toggle', { state: true })
+    } else {
+      dispatchCustomEvent('stackVisualiser:toggle', { state: false })
+    }
+  }, [activePanel])
+
   return (
     <Wrapper>
       {activePanel && (

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -276,12 +276,16 @@ const useActions = (registerHotkeys = false) => {
       hotkeys: [{ key: '1', shift: true }],
       handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'test' })
     },
-    FILE_INFO: {
+    STEPPING_LAB: {
       hotkeys: [{ key: '2', shift: true }],
+      handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'step' })
+    },
+    FILE_INFO: {
+      hotkeys: [{ key: '3', shift: true }],
       handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'about' })
     },
     FILE_OPTIONS: {
-      hotkeys: [{ key: '3', shift: true }],
+      hotkeys: [{ key: '4', shift: true }],
       handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'options' })
     },
     CONVERT_TO_DFA: {

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -68,7 +68,8 @@ export interface CustomEvents {
   'showWarning': string,
   'modal:deleteConfirm': null,
   'modal:import': null,
-  'showSharing': null
+  'showSharing': null,
+  'stackVisualiser:toggle': { state: boolean }
 }
 
 /**

--- a/packages/simulation/src/Step.ts
+++ b/packages/simulation/src/Step.ts
@@ -49,4 +49,12 @@ export class GraphStepper<S extends State, T extends BaseAutomataTransition> {
     this.frontier = [this.graph.initial]
     return this.frontier
   }
+
+  public canMoveForward (): boolean {
+    return this.frontier.some(node => this.graph.getSuccessors(node).length > 0)
+  }
+
+  public canMoveBackward (): boolean {
+    return this.frontier.some(node => !!node.parent)
+  }
 }

--- a/packages/simulation/src/utils.ts
+++ b/packages/simulation/src/utils.ts
@@ -121,12 +121,9 @@ export function buildProblem <M extends ProjectGraph> (graph: M, input: string):
  * Creates a GraphStepper for stepping through how a frontend graph simulates an input
  * @see GraphStepper
  */
-export const graphStepper = <P extends FSAProjectGraph | PDAProjectGraph>(graph: P, input: string) => {
-  // Just in case an assertion makes the type not be FSA/PDA
-  if (graph.projectType as string === 'TM') return null
+export const graphStepper = <P extends FSAProjectGraph | PDAProjectGraph | TMProjectGraph>(graph: P, input: string) => {
   const problem = buildProblem(graph, input)
   if (!problem) return null
-  // We know that problem is PDAGraph | FSAGraph so this is safe
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return new GraphStepper<StateMapping<P>, TransitionMapping<P>>(problem as any)
 }


### PR DESCRIPTION
This update doesn't add all the enhancements originally aimed for -- disabling buttons when movement isn't possible relies on useState, which hasn't been behaving as expected in the SteppingLab component. Nevertheless, it does introduce several improvements and fixes a few bugs that emerged after the previous one was addressed.

Changes:

- Implemented Shift+2 keyboard shortcut for toggling Stepping Lab visibility.

- On mounting the Stepping Lab, the initial state is now highlighted.

- Integrated Stepping Lab support for TMs. Prior to this, utilising the Stepping Lab within a TM project led to an unhandled error causing the app to crash in dev mode.

- Removed stack visualiser when Testing Lab is inactive. While testing the Stepping Lab, it was found that the stack visualiser remained static throughout input string traversal. Given the Stepping Lab's inherent support for nondeterminism, omitting the stack visualiser outside of the Testing Lab seemed like a logical choice in order to avoid confusion.

Future Enhancements:
The initial issue (#423)  proposed a visual indicator for the character being processed during traversal and an alert or cue for unaccepted trace input. However, given the current support for nondeterminism in the Stepping Lab, these features don't actually seem viable. Since the Testing Lab already possesses these functionalities, their absence in the Stepping Lab isn't pressing.

Disabling buttons when movement isn't possible remains a priority.
