### PR TITLE
Fixes left bounded TM tape

### DIFF
--- a/packages/simulation/src/TMSearch.ts
+++ b/packages/simulation/src/TMSearch.ts
@@ -39,13 +39,17 @@ export class TMGraph extends Graph<TMState, TMAutomataTransition> {
 
       // Undefined means its out of tape bounds, so we treat that has a lambda transition
       const symbol = tapeTrace[tapePointer] ?? ''
-      const nextTape = this.progressTape(node, transition)
+      let nextTape = this.progressTape(node, transition)
 
       // If there is no next state
       if (
-        nextState === undefined || (!transition.read.includes(symbol)) || nextTape.pointer < 0
+        nextState === undefined || (!transition.read.includes(symbol))
       ) {
         continue
+      }
+      // Add a lambda on the tape to the start of the known tape
+      if (nextTape.pointer < 0) {
+        nextTape = { pointer: 0, trace: ['', ...nextTape.trace] }
       }
       if (transition.read === symbol) {
         const graphState = new TMState(


### PR DESCRIPTION
Closes #361.

The search could not transition if you expected a lambda at the front of the string, leading the TM tapes to be bounded on the left when they should be infinite.

![image](https://github.com/automatarium/automatarium/assets/82514325/d4172354-ced8-4b07-9fb2-316eb34e41fb)

Now:

![image](https://github.com/automatarium/automatarium/assets/82514325/ac847426-ff16-43ed-80e1-293f16e03f79)

Unsure how severely this would impact efficiency.
