### PR TITLE
Enhance multiple inputs per transition

### DIFF
--- a/frontend/src/components/InputDialogs/InputDialogs.tsx
+++ b/frontend/src/components/InputDialogs/InputDialogs.tsx
@@ -85,7 +85,6 @@ const InputDialogs = () => {
 
   const inputWriteRef = useRef()
   const inputDirectionRef = useRef()
-  const [read, setRead] = useState('')
   const [write, setWrite] = useState('')
   const [direction, setDirection] = useState<TMDirection | ''>('R')
   const editTransition = useProjectStore(s => s.editTransition)
@@ -109,7 +108,7 @@ const InputDialogs = () => {
     switch (projectType) {
       case 'TM':
         assertType<TMAutomataTransition>(transition)
-        setRead(transition?.read ?? '')
+        setValue(transition?.read ?? '')
         setWrite(transition?.write ?? '')
         setDirection(transition?.direction)
         setDialog({
@@ -176,7 +175,12 @@ const InputDialogs = () => {
   }
 
   const saveTMTransition = () => {
-    editTransition({ id: dialog.id, read, write, direction: direction || 'R' } as TMAutomataTransition)
+    editTransition({
+      id: dialog.id,
+      read: formatInput(value),
+      write,
+      direction: direction || 'R'
+    } as TMAutomataTransition)
     commit()
     hideDialog()
   }
@@ -275,11 +279,6 @@ const InputDialogs = () => {
     stateName: saveStateName,
     stateLabel: saveStateLabel
   } as Record<DialogType, () => void>)[dialog?.type]
-
-  const handleReadIn = (e: InputEvent) => {
-    const input = e.target.value.toString()
-    setRead(input[input.length - 1] ?? '')
-  }
 
   const handleWriteIn = (e: InputEvent) => {
     const input = e.target.value.toString()
@@ -383,8 +382,8 @@ const InputDialogs = () => {
           <InputWrapper>
             <Input
               ref={inputRef}
-              value={read}
-              onChange={handleReadIn}
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
               onKeyUp={handleSave}
               placeholder={'λ\t(read)'}
               style={TRANSITION_INPUT_STYLE}

--- a/frontend/src/components/InputDialogs/InputDialogs.tsx
+++ b/frontend/src/components/InputDialogs/InputDialogs.tsx
@@ -6,6 +6,7 @@ import { useProjectStore, useViewStore } from '/src/stores'
 import useEvent from '/src/hooks/useEvent'
 import { locateTransition } from '/src/util/states'
 import { lerpPoints } from '/src/util/points'
+import { possibleOrOperators } from '/src/util/orOperators'
 
 import { InputWrapper, SubmitButton } from './inputDialogsStyle'
 import {
@@ -152,8 +153,13 @@ const InputDialogs = () => {
    * e.g. [a-b]ad[l-k] becomes ad[a-b][l-k]
    */
   const formatInput = (input: string): string => {
-    // Remove any given OR operator to be reintroduced during formatting
-    input = input.split(orOperator).join('')
+    // Remove whitespace
+    input = input.replace(/\s+/g, '')
+
+    // Remove all possible OR operators from the input
+    for (const op of possibleOrOperators(orOperator)) {
+      input = input.split(op).join('')
+    }
 
     const ranges = input.match(/\[(.*?)]/g)
     const chars = input.replace(/\[(.*?)]/g, '')

--- a/frontend/src/components/InputDialogs/InputDialogs.tsx
+++ b/frontend/src/components/InputDialogs/InputDialogs.tsx
@@ -144,7 +144,7 @@ const InputDialogs = () => {
     }
 
     focusInput()
-  }, arr)
+  }, [arr, orOperator])
 
   const saveTransition = () => {
     editTransition({

--- a/frontend/src/components/InputDialogs/InputDialogs.tsx
+++ b/frontend/src/components/InputDialogs/InputDialogs.tsx
@@ -94,6 +94,7 @@ const InputDialogs = () => {
   const screenToViewSpace = useViewStore(s => s.screenToViewSpace)
   const statePrefix = useProjectStore(s => s.project.config.statePrefix)
   const projectType = useProjectStore(s => s.project.config.type)
+  const orOperator = useProjectStore(s => s.project.config.orOperator)
   const hideDialog = useCallback(() => setDialog({ ...dialog, visible: false }), [dialog])
   const focusInput = useCallback(() => setTimeout(() => inputRef.current?.focus(), 100), [inputRef.current])
   const arr = [inputWriteRef.current, inputDirectionRef.current, inputRef.current]
@@ -146,11 +147,14 @@ const InputDialogs = () => {
   }, arr)
 
   /**
-   * Rearranges a read string so that all single characters come before ranges.
+   * Removes OR operators and rearranges the read string when a range is present
+   * All single characters come before ranges
    * e.g. [a-b]ad[l-k] becomes ad[a-b][l-k]
-   * This is just want it was like before so assuming there is a design reason
    */
-  const formatRangeChars = (input: string): string => {
+  const formatInput = (input: string): string => {
+    // Remove any given OR operator to be reintroduced during formatting
+    input = input.split(orOperator).join('')
+
     const ranges = input.match(/\[(.*?)]/g)
     const chars = input.replace(/\[(.*?)]/g, '')
     return `${Array.from(new Set(chars)).join('')}${ranges ? ranges.join('') : ''}`
@@ -159,7 +163,7 @@ const InputDialogs = () => {
   const saveTransition = () => {
     editTransition({
       id: dialog.id,
-      read: formatRangeChars(value)
+      read: formatInput(value)
     })
     commit()
     hideDialog()
@@ -174,9 +178,9 @@ const InputDialogs = () => {
   const savePDATransition = () => {
     editTransition({
       id: dialog.id,
-      read: formatRangeChars(value),
-      pop: formatRangeChars(valuePop),
-      push: formatRangeChars(valuePush)
+      read: formatInput(value),
+      pop: formatInput(valuePop),
+      push: formatInput(valuePush)
     } as PDAAutomataTransition)
     commit()
     hideDialog()

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -24,6 +24,7 @@ import {
   TMDirection,
   assertType
 } from '/src/types/ProjectTypes'
+import { splitCharsWithOr, formatInput } from '/src/util/orOperators'
 
 const InputTransitionGroup = () => {
   const inputRef = useRef<HTMLInputElement>()
@@ -51,6 +52,7 @@ const InputTransitionGroup = () => {
 
   const statePrefix = useProjectStore(s => s.project.config.statePrefix)
   const projectType = useProjectStore(s => s.project.config.type)
+  const orOperator = useProjectStore(s => s.project.config.orOperator)
 
   const editTransition = useProjectStore(s => s.editTransition)
   const createTransition = useProjectStore(s => s.createTransition)
@@ -158,7 +160,7 @@ const InputTransitionGroup = () => {
 
   const saveNewFSATransition = () => {
     const newId = createNewTransition()
-    editTransition({ id: newId, read: readValue } as FSAAutomataTransition)
+    editTransition({ id: newId, read: formatInput(readValue, orOperator) } as FSAAutomataTransition)
     resetInputFields()
   }
 
@@ -189,7 +191,7 @@ const InputTransitionGroup = () => {
     const newId = createNewTransition()
     editTransition({
       id: newId,
-      read: readValue,
+      read: formatInput(readValue, orOperator),
       pop: popValue,
       push: pushValue
     } as PDAAutomataTransition)
@@ -247,15 +249,15 @@ const InputTransitionGroup = () => {
     const newId = createNewTransition()
     editTransition({
       id: newId,
-      read: readValue,
+      read: formatInput(readValue, orOperator),
       write: writeValue,
       direction: dirValue === '' ? 'R' : dirValue
     } as TMAutomataTransition)
     resetInputFields()
   }
 
-  /** TMs operate with the assumption of reading and writing one character */
-  const tmReadWriteValidate = (e: ChangeEvent<HTMLInputElement>) => {
+  /** TMs operate with the assumption of writing one character */
+  const tmWriteValidate = (e: ChangeEvent<HTMLInputElement>) => {
     const input = e.target.value.toString()
     return input[input.length - 1] ?? ''
   }
@@ -274,10 +276,7 @@ const InputTransitionGroup = () => {
       <Input
         ref={inputRef}
         value={readValue}
-        onChange={e => {
-          const r = tmReadWriteValidate(e)
-          setReadValue(r)
-        }}
+        onChange={e => { setReadValue(e.target.value) }}
         onClick={() => setSelectedIndex(-1)}
         onKeyUp={handleKeyUp}
         onFocus={e => e.target.select()}
@@ -289,7 +288,7 @@ const InputTransitionGroup = () => {
       <Input
         value={writeValue}
         onChange={e => {
-          const w = tmReadWriteValidate(e)
+          const w = tmWriteValidate(e)
           setWriteValue(w)
         }}
         onClick={() => setSelectedIndex(-1)}
@@ -346,9 +345,9 @@ const InputTransitionGroup = () => {
           {transitionsList.map((t, i) => <InputWrapper key={i}>
           <Input
               ref={transitionListRef[i] ?? null}
-              value={t.read}
+              value={splitCharsWithOr(t.read, orOperator)}
               onChange={e => {
-                saveFSATransition({ id: t.id, read: e.target.value })
+                saveFSATransition({ id: t.id, read: formatInput(e.target.value, orOperator) })
                 setSelectedIndex(i)
               }}
               onClick={() => setSelectedIndex(i)}
@@ -371,11 +370,11 @@ const InputTransitionGroup = () => {
             <InputSpacingWrapper>
               <Input
                 ref={transitionListRef[i] ?? null}
-                value={t.read}
+                value={splitCharsWithOr(t.read, orOperator)}
                 onChange={e => {
                   savePDATransition({
                     id: t.id,
-                    read: e.target.value,
+                    read: formatInput(e.target.value, orOperator),
                     pop: t.pop,
                     push: t.push
                   })
@@ -440,12 +439,11 @@ const InputTransitionGroup = () => {
             <InputSpacingWrapper>
               <Input
                 ref={transitionListRef[i] ?? null}
-                value={t.read}
+                value={splitCharsWithOr(t.read, orOperator)}
                 onChange={e => {
-                  const r = tmReadWriteValidate(e)
                   saveTMTransition({
                     id: t.id,
-                    read: r,
+                    read: formatInput(e.target.value, orOperator),
                     write: t.write,
                     direction: t.direction
                   })
@@ -462,7 +460,7 @@ const InputTransitionGroup = () => {
               <Input
                 value={t.write}
                 onChange={e => {
-                  const w = tmReadWriteValidate(e)
+                  const w = tmWriteValidate(e)
                   saveTMTransition({
                     id: t.id,
                     read: t.read,

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -84,7 +84,7 @@ const InputTransitionGroup = () => {
     ).map(t => t.id)
     setIdList([...allIdList])
     setModalOpen(true)
-  })
+  }, [orOperator])
 
   const retrieveTransitions = () => {
     const { transitions } = useProjectStore.getState()?.project ?? {}

--- a/frontend/src/components/Sidepanel/Panels/Options/Options.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Options/Options.tsx
@@ -6,6 +6,7 @@ import { ColourName } from '/src/config'
 
 const Options = () => {
   const statePrefix = useProjectStore(s => s.project?.config?.statePrefix)
+  const orOperator = useProjectStore(s => s.project?.config?.orOperator)
   const projectColor = useProjectStore(s => s.project?.config?.color)
   const updateConfig = useProjectStore(s => s.updateConfig)
 
@@ -21,6 +22,21 @@ const Options = () => {
           style={{ width: '8ch' }}
           value={statePrefix ?? 'q'}
           onChange={e => updateConfig({ statePrefix: e.target.value })}
+        />
+      </Preference>
+    </Wrapper>
+
+    <SectionLabel>Operators</SectionLabel>
+    <Wrapper>
+      <Preference
+        label="OR operator"
+        description="Used to separate input characters"
+      >
+        <Input
+          small
+          style={{ width: '8ch' }}
+          value={orOperator ?? '|'}
+          onChange={e => updateConfig({ orOperator: e.target.value })}
         />
       </Preference>
     </Wrapper>

--- a/frontend/src/components/Sidepanel/Panels/Options/Options.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Options/Options.tsx
@@ -33,11 +33,18 @@ const Options = () => {
         description="Used to separate input characters"
       >
         <Input
+          type="select"
           small
-          style={{ width: '8ch' }}
-          value={orOperator ?? '|'}
+          value={(orOperator === '' || !orOperator) ? '|' : orOperator}
           onChange={e => updateConfig({ orOperator: e.target.value })}
-        />
+        >
+          <option value="∣">∣</option>
+          <option value="∥">∥</option>
+          <option value="＋">＋</option>
+          <option value="∨">v</option>
+          <option value="OR">OR</option>
+          <option value=" ">None</option>
+        </Input>
       </Preference>
     </Wrapper>
 

--- a/frontend/src/components/TraceStepBubble/TraceStepBubble.tsx
+++ b/frontend/src/components/TraceStepBubble/TraceStepBubble.tsx
@@ -45,7 +45,7 @@ const TraceStepBubble = ({ stateID, input, index }: TraceStepBubbleProps) => {
           <Pointer />
           <TickerTape $index={index}>
             <SerratedEdge />
-            {input?.split('').map((symbol, i) => <TickerTapeCell key={i} $consumed={i < index}>
+            {input?.split('').map((symbol, i) => <TickerTapeCell key={i} $consumed={i < index - 1 }>
               {symbol}
             </TickerTapeCell>)}
             <SerratedEdge flipped />

--- a/frontend/src/components/TraceStepBubble/traceStepBubbleStyle.ts
+++ b/frontend/src/components/TraceStepBubble/traceStepBubbleStyle.ts
@@ -39,7 +39,7 @@ export const TickerTape = styled('div')<{$index: number}>`
   flex-direction: row;
   width: max-content;
 
-  transform: translateX(calc(${p => -p.$index + 2} * var(--cell-width)));
+  transform: translateX(calc(${p => -p.$index + 4} * var(--cell-width)));
   transition: transform .1s;
 `
 

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -8,7 +8,6 @@ import { useSelectionStore } from '/src/stores'
 import { pathStyles, pathSelectedClass, ghostStyles } from './transitionSetStyle'
 import { PositionedTransition } from '/src/util/states'
 import { assertType, Coordinate, PDAAutomataTransition, ProjectType, TMAutomataTransition } from '/src/types/ProjectTypes'
-import { possibleOrOperators } from '/src/util/orOperators'
 
 /**
  * Creates the transition text depending on the project type. Uses the following notation
@@ -31,21 +30,17 @@ const makeTransitionText = (type: ProjectType, t: PositionedTransition): string 
 }
 
 // If the read length is greater than 1, add OR symbols between each character
-const splitCharsWithOr = (read: string, orOperator: string, type: ProjectType): string => {
+const splitCharsWithOr = (text: string, orOperator: string, type: ProjectType): string => {
   switch (type) {
     case 'TM':
-      return read
+      return text
     case 'PDA':
-      return read
+      return text
     case 'FSA': {
-      // This will replace any of the possible operators with the chosen orOperator
-      for (const op of possibleOrOperators(orOperator)) {
-        read = read.split(op).join(orOperator)
-      }
-      if (!read || read.length <= 1) return read
+      if (!text || text.length <= 1) return text
       const joinStr = `  ${orOperator}  `
       // Don't insert OR symbols inside ranges
-      return read.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
+      return text.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
     }
   }
 }

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -25,8 +25,16 @@ const makeTransitionText = (type: ProjectType, t: PositionedTransition): string 
       assertType<PDAAutomataTransition>(t)
       return `${t.read || 'λ'},${t.pop || 'λ'};${t.push || 'λ'}`
     case 'FSA':
-      return t.read || 'λ'
+      return splitCharsWithOr(t.read) || 'λ'
   }
+}
+
+// If the read length is greater than 1, add OR symbols between each character
+const splitCharsWithOr = (read: string): string => {
+  if (read && read.length > 1) {
+    return read.split('').join(' | ')
+  }
+  return read
 }
 
 // Direction that a transition can bend
@@ -193,6 +201,20 @@ const Transition = ({
   // 'under' transitions require more spacing
   const initialOffset = ((bendDirection === 'under' ? 1 : 0.3) * offsetDirection) + 'em'
 
+  const coloriseOrSymbols = (text: string) => {
+    const elements: React.ReactNode[] = []
+    const parts = text.split('|')
+
+    parts.forEach((part, index) => {
+      elements.push(<tspan>{part}</tspan>)
+      if (index !== parts.length - 1) {
+        elements.push(<tspan fill="#999">|</tspan>)
+      }
+    })
+
+    return elements
+  }
+
   return <g>
     {/* The edge itself */}
     <path
@@ -233,7 +255,7 @@ const Transition = ({
             onMouseUp={handleTransitionMouseUp(t)}
             onDoubleClick={handleTransitionDoubleClick(t)}
             x={midPoint.x}>
-              {makeTransitionText(projectType, t)}
+            {coloriseOrSymbols(makeTransitionText(projectType, t))}
           </tspan>
         })}
     </text>

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -207,9 +207,9 @@ const Transition = ({
     const parts = text.split(orOperator)
 
     parts.forEach((part, index) => {
-      elements.push(<tspan>{part}</tspan>)
+      elements.push(<tspan key={`part-${index}`}>{part}</tspan>)
       if (index !== parts.length - 1) {
-        elements.push(<tspan fill="#999">{orOperator}</tspan>)
+        elements.push(<tspan key={`operator-${index}`} fill="#999">{orOperator}</tspan>)
       }
     })
     return elements

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -25,16 +25,17 @@ const makeTransitionText = (type: ProjectType, t: PositionedTransition): string 
       assertType<PDAAutomataTransition>(t)
       return `${t.read || 'λ'},${t.pop || 'λ'};${t.push || 'λ'}`
     case 'FSA':
-      return splitCharsWithOr(t.read) || 'λ'
+      return t.read || 'λ'
   }
 }
 
 // If the read length is greater than 1, add OR symbols between each character
-const splitCharsWithOr = (read: string): string => {
+const splitCharsWithOr = (read: string, orOperator: string): string => {
   if (read && read.length > 1) {
-    return read.split('').join(' | ')
+    const joinStr = `  ${orOperator}  `;
+    return read.split('').join(joinStr);
   }
-  return read
+  return read;
 }
 
 // Direction that a transition can bend
@@ -146,6 +147,7 @@ const Transition = ({
 
   const selectedTransitions = useSelectionStore(s => s.selectedTransitions)
   const setSelected = transitions.some(t => selectedTransitions.includes(t.id))
+  const orOperator = useProjectStore(s => s.project?.config?.orOperator)
 
   // We want transitions going from left to right to be bending like a hill and in the other direction bending like
   // a valley
@@ -201,18 +203,19 @@ const Transition = ({
   // 'under' transitions require more spacing
   const initialOffset = ((bendDirection === 'under' ? 1 : 0.3) * offsetDirection) + 'em'
 
-  const coloriseOrSymbols = (text: string) => {
-    const elements: React.ReactNode[] = []
-    const parts = text.split('|')
+  const formatOrSymbols = (text: string) => {
+    text = splitCharsWithOr(text, orOperator)
+    const elements: React.ReactNode[] = [];
+    const parts = text.split(orOperator);  
 
     parts.forEach((part, index) => {
-      elements.push(<tspan>{part}</tspan>)
+      elements.push(<tspan>{part}</tspan>);
       if (index !== parts.length - 1) {
-        elements.push(<tspan fill="#999">|</tspan>)
+        elements.push(<tspan fill="#999">{orOperator}</tspan>);  
       }
-    })
+    });
 
-    return elements
+    return elements;
   }
 
   return <g>
@@ -255,7 +258,7 @@ const Transition = ({
             onMouseUp={handleTransitionMouseUp(t)}
             onDoubleClick={handleTransitionDoubleClick(t)}
             x={midPoint.x}>
-            {coloriseOrSymbols(makeTransitionText(projectType, t))}
+            {formatOrSymbols(makeTransitionText(projectType, t))}
           </tspan>
         })}
     </text>

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -8,6 +8,7 @@ import { useSelectionStore } from '/src/stores'
 import { pathStyles, pathSelectedClass, ghostStyles } from './transitionSetStyle'
 import { PositionedTransition } from '/src/util/states'
 import { assertType, Coordinate, PDAAutomataTransition, ProjectType, TMAutomataTransition } from '/src/types/ProjectTypes'
+import { splitCharsWithOr } from '/src/util/orOperators'
 
 /**
  * Creates the transition text depending on the project type. Uses the following notation
@@ -27,14 +28,6 @@ const makeTransitionText = (type: ProjectType, orOperator: string, t: Positioned
     case 'FSA':
       return splitCharsWithOr(t.read, orOperator) || 'λ'
   }
-}
-
-// If the read length is greater than 1, add OR symbols between each character
-const splitCharsWithOr = (text: string, orOperator: string): string => {
-  if (!text || text.length <= 1) return text
-  const joinStr = `  ${orOperator}  `
-  // Don't insert OR symbols inside ranges
-  return text.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
 }
 
 // Direction that a transition can bend

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -30,12 +30,19 @@ const makeTransitionText = (type: ProjectType, t: PositionedTransition): string 
 }
 
 // If the read length is greater than 1, add OR symbols between each character
-const splitCharsWithOr = (read: string, orOperator: string): string => {
-  if (!read || read.length <= 1) return read
-
-  const joinStr = `  ${orOperator}  `
-  // Don't insert OR symbols inside ranges
-  return read.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
+const splitCharsWithOr = (read: string, orOperator: string, type: ProjectType): string => {
+  switch (type) {
+    case 'TM':
+      return read
+    case 'PDA':
+      return read
+    case 'FSA': {
+      if (!read || read.length <= 1) return read
+      const joinStr = `  ${orOperator}  `
+      // Don't insert OR symbols inside ranges
+      return read.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
+    }
+  }
 }
 
 // Direction that a transition can bend
@@ -204,7 +211,7 @@ const Transition = ({
   const initialOffset = ((bendDirection === 'under' ? 1 : 0.3) * offsetDirection) + 'em'
 
   const formatOrSymbols = (text: string) => {
-    text = splitCharsWithOr(text, orOperator)
+    text = splitCharsWithOr(text, orOperator, projectType)
     const elements: React.ReactNode[] = []
     const parts = text.split(orOperator)
 

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -31,11 +31,11 @@ const makeTransitionText = (type: ProjectType, t: PositionedTransition): string 
 
 // If the read length is greater than 1, add OR symbols between each character
 const splitCharsWithOr = (read: string, orOperator: string): string => {
-  if (!read || read.length <= 1) return read;
+  if (!read || read.length <= 1) return read
 
-  const joinStr = `  ${orOperator}  `;
+  const joinStr = `  ${orOperator}  `
   // Don't insert OR symbols inside ranges
-  return read.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr);
+  return read.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
 }
 
 // Direction that a transition can bend
@@ -205,16 +205,16 @@ const Transition = ({
 
   const formatOrSymbols = (text: string) => {
     text = splitCharsWithOr(text, orOperator)
-    const elements: React.ReactNode[] = [];
-    const parts = text.split(orOperator);  
+    const elements: React.ReactNode[] = []
+    const parts = text.split(orOperator)
 
     parts.forEach((part, index) => {
-      elements.push(<tspan>{part}</tspan>);
+      elements.push(<tspan>{part}</tspan>)
       if (index !== parts.length - 1) {
-        elements.push(<tspan fill="#999">{orOperator}</tspan>);  
+        elements.push(<tspan fill="#999">{orOperator}</tspan>)
       }
-    });
-    return elements;
+    })
+    return elements
   }
 
   return <g>

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -15,34 +15,26 @@ import { assertType, Coordinate, PDAAutomataTransition, ProjectType, TMAutomataT
  * - PDA: read,pop;direction
  * - FSA: read
  */
-const makeTransitionText = (type: ProjectType, t: PositionedTransition): string => {
+const makeTransitionText = (type: ProjectType, orOperator: string, t: PositionedTransition): string => {
   // Since the type can't be narrowed, we need to narrow ourselves inside the blocks
   switch (type) {
     case 'TM':
       assertType<TMAutomataTransition>(t)
-      return `${t.read || 'λ'},${t.write || 'λ'};${t.direction || 'λ'}`
+      return `${splitCharsWithOr(t.read, orOperator) || 'λ'},${t.write || 'λ'};${t.direction || 'λ'}`
     case 'PDA':
       assertType<PDAAutomataTransition>(t)
-      return `${t.read || 'λ'},${t.pop || 'λ'};${t.push || 'λ'}`
+      return `${splitCharsWithOr(t.read, orOperator) || 'λ'},${t.pop || 'λ'};${t.push || 'λ'}`
     case 'FSA':
-      return t.read || 'λ'
+      return splitCharsWithOr(t.read, orOperator) || 'λ'
   }
 }
 
 // If the read length is greater than 1, add OR symbols between each character
-const splitCharsWithOr = (text: string, orOperator: string, type: ProjectType): string => {
-  switch (type) {
-    case 'TM':
-      return text
-    case 'PDA':
-      return text
-    case 'FSA': {
-      if (!text || text.length <= 1) return text
-      const joinStr = `  ${orOperator}  `
-      // Don't insert OR symbols inside ranges
-      return text.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
-    }
-  }
+const splitCharsWithOr = (text: string, orOperator: string): string => {
+  if (!text || text.length <= 1) return text
+  const joinStr = `  ${orOperator}  `
+  // Don't insert OR symbols inside ranges
+  return text.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
 }
 
 // Direction that a transition can bend
@@ -211,7 +203,6 @@ const Transition = ({
   const initialOffset = ((bendDirection === 'under' ? 1 : 0.3) * offsetDirection) + 'em'
 
   const formatOrSymbols = (text: string) => {
-    text = splitCharsWithOr(text, orOperator, projectType)
     const elements: React.ReactNode[] = []
     const parts = text.split(orOperator)
 
@@ -264,7 +255,7 @@ const Transition = ({
             onMouseUp={handleTransitionMouseUp(t)}
             onDoubleClick={handleTransitionDoubleClick(t)}
             x={midPoint.x}>
-            {formatOrSymbols(makeTransitionText(projectType, t))}
+            {formatOrSymbols(makeTransitionText(projectType, orOperator, t))}
           </tspan>
         })}
     </text>

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -31,11 +31,11 @@ const makeTransitionText = (type: ProjectType, t: PositionedTransition): string 
 
 // If the read length is greater than 1, add OR symbols between each character
 const splitCharsWithOr = (read: string, orOperator: string): string => {
-  if (read && read.length > 1) {
-    const joinStr = `  ${orOperator}  `;
-    return read.split('').join(joinStr);
-  }
-  return read;
+  if (!read || read.length <= 1) return read;
+
+  const joinStr = `  ${orOperator}  `;
+  // Don't insert OR symbols inside ranges
+  return read.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr);
 }
 
 // Direction that a transition can bend
@@ -214,7 +214,6 @@ const Transition = ({
         elements.push(<tspan fill="#999">{orOperator}</tspan>);  
       }
     });
-
     return elements;
   }
 

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -8,6 +8,7 @@ import { useSelectionStore } from '/src/stores'
 import { pathStyles, pathSelectedClass, ghostStyles } from './transitionSetStyle'
 import { PositionedTransition } from '/src/util/states'
 import { assertType, Coordinate, PDAAutomataTransition, ProjectType, TMAutomataTransition } from '/src/types/ProjectTypes'
+import { possibleOrOperators } from '/src/util/orOperators'
 
 /**
  * Creates the transition text depending on the project type. Uses the following notation
@@ -37,6 +38,10 @@ const splitCharsWithOr = (read: string, orOperator: string, type: ProjectType): 
     case 'PDA':
       return read
     case 'FSA': {
+      // This will replace any of the possible operators with the chosen orOperator
+      for (const op of possibleOrOperators(orOperator)) {
+        read = read.split(op).join(orOperator)
+      }
       if (!read || read.length <= 1) return read
       const joinStr = `  ${orOperator}  `
       // Don't insert OR symbols inside ranges

--- a/frontend/src/config/projects.ts
+++ b/frontend/src/config/projects.ts
@@ -6,6 +6,7 @@ export const SCHEMA_VERSION = packageConfig.schemaVersion
 export const APP_VERSION = packageConfig.version
 export const DEFAULT_PROJECT_TYPE = 'FSA'
 export const DEFAULT_STATE_PREFIX = 'q'
+export const DEFAULT_OR_OPERATOR = '|'
 export const DEFAULT_ACCEPTANCE_CRITERIA = 'both'
 export const DEFAULT_PROJECT_COLOR: Record<ProjectType, ColourName> = {
   FSA: 'orange',

--- a/frontend/src/stores/useProjectStore.ts
+++ b/frontend/src/stores/useProjectStore.ts
@@ -428,7 +428,7 @@ const useProjectStore = create<ProjectStore>()(persist((set: SetState<ProjectSto
       initialState: project.initialState,
       projectType: project.projectType,
       states: project.states,
-      transitions: project.projectType === 'TM' ? project.transitions : expandTransitions(project.transitions)
+      transitions: expandTransitions(project.transitions)
     } as ProjectGraph
   },
 

--- a/frontend/src/stores/useProjectStore.ts
+++ b/frontend/src/stores/useProjectStore.ts
@@ -22,6 +22,7 @@ import {
   APP_VERSION,
   SCHEMA_VERSION,
   DEFAULT_STATE_PREFIX,
+  DEFAULT_OR_OPERATOR,
   DEFAULT_PROJECT_TYPE,
   DEFAULT_ACCEPTANCE_CRITERIA,
   DEFAULT_PROJECT_COLOR
@@ -70,6 +71,7 @@ export const createNewProject = (projectType: ProjectType = DEFAULT_PROJECT_TYPE
   config: {
     type: projectType,
     statePrefix: DEFAULT_STATE_PREFIX,
+    orOperator: DEFAULT_OR_OPERATOR,
     acceptanceCriteria: DEFAULT_ACCEPTANCE_CRITERIA,
     color: DEFAULT_PROJECT_COLOR[projectType]
   }

--- a/frontend/src/types/ProjectTypes.ts
+++ b/frontend/src/types/ProjectTypes.ts
@@ -27,6 +27,7 @@ export interface ProjectConfig {
     acceptanceCriteria: string,
     // Could be made into enum
     color: ColourName | '',
+    orOperator: string,
     statePrefix: string,
     type: ProjectType
 }

--- a/frontend/src/util/orOperators.ts
+++ b/frontend/src/util/orOperators.ts
@@ -26,3 +26,30 @@ export const possibleOrOperators = (orOperator: string): string[] => {
       return [orOperator]
   }
 }
+
+// If the read length is greater than 1, add OR symbols between each character
+export const splitCharsWithOr = (text: string, orOperator: string): string => {
+  if (!text || text.length <= 1) return text
+  const joinStr = `  ${orOperator}  `
+  // Don't insert OR symbols inside ranges
+  return text.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
+}
+
+/**
+ * Removes OR operators and rearranges the read string when a range is present
+ * All single characters come before ranges
+ * e.g. [a-b]ad[l-k] becomes ad[a-b][l-k]
+ */
+export const formatInput = (input: string, orOperator: string): string => {
+  // Remove whitespace
+  input = input.replace(/\s+/g, '')
+
+  // Remove all possible OR operators from the input
+  for (const op of possibleOrOperators(orOperator)) {
+    input = input.split(op).join('')
+  }
+
+  const ranges = input.match(/\[(.*?)]/g)
+  const chars = input.replace(/\[(.*?)]/g, '')
+  return `${Array.from(new Set(chars)).join('')}${ranges ? ranges.join('') : ''}`
+}

--- a/frontend/src/util/orOperators.ts
+++ b/frontend/src/util/orOperators.ts
@@ -30,7 +30,9 @@ export const possibleOrOperators = (orOperator: string): string[] => {
 // If the read length is greater than 1, add OR symbols between each character
 export const splitCharsWithOr = (text: string, orOperator: string): string => {
   if (!text || text.length <= 1) return text
-  const joinStr = `  ${orOperator}  `
+  let joinStr = ' '
+  if (orOperator !== ' ') { joinStr = ` ${orOperator} ` }
+
   // Don't insert OR symbols inside ranges
   return text.split(/(\[.*?])|(?=.)/g).filter(Boolean).join(joinStr)
 }

--- a/frontend/src/util/orOperators.ts
+++ b/frontend/src/util/orOperators.ts
@@ -1,0 +1,29 @@
+
+export const possibleOrOperators = (orOperator: string): string[] => {
+  switch (orOperator) {
+    case '+':
+    case '＋':
+      return ['+', '＋']
+
+    case '∣':
+    case '|':
+      return ['∣', '|', '|']
+
+    case '∥':
+    case '||':
+    case '∣∣':
+      return ['∥', '||']
+
+    case '∨':
+    case 'v':
+    case 'V':
+      return ['∨', 'v', 'V']
+
+    case ' ':
+    case '':
+      return [' ', '']
+
+    default:
+      return [orOperator]
+  }
+}

--- a/frontend/src/util/orOperators.ts
+++ b/frontend/src/util/orOperators.ts
@@ -1,4 +1,3 @@
-
 export const possibleOrOperators = (orOperator: string): string[] => {
   switch (orOperator) {
     case '+':

--- a/packages/jflap-translator/src/convertJFLAP.ts
+++ b/packages/jflap-translator/src/convertJFLAP.ts
@@ -1,6 +1,6 @@
 import { ElementCompact, xml2js } from 'xml-js'
 
-import { DEFAULT_PROJECT_COLOR, DEFAULT_STATE_PREFIX, DEFAULT_ACCEPTANCE_CRITERIA, SCHEMA_VERSION, APP_VERSION } from 'frontend/src/config'
+import { DEFAULT_PROJECT_COLOR, DEFAULT_STATE_PREFIX, DEFAULT_OR_OPERATOR, DEFAULT_ACCEPTANCE_CRITERIA, SCHEMA_VERSION, APP_VERSION } from 'frontend/src/config'
 import {
   ProjectType,
   Project,
@@ -95,6 +95,7 @@ export const convertJFLAPProject = (jflapProject: ElementCompact): Project => {
       type: projectType,
       statePrefix: DEFAULT_STATE_PREFIX,
       color: DEFAULT_PROJECT_COLOR[projectType],
+      orOperator: DEFAULT_OR_OPERATOR,
       acceptanceCriteria: projectType === 'PDA' ? DEFAULT_ACCEPTANCE_CRITERIA : undefined
     },
     meta: {

--- a/packages/jflap-translator/tests/convert.test.ts
+++ b/packages/jflap-translator/tests/convert.test.ts
@@ -13,7 +13,8 @@ describe('Importing single attribute', () => {
     expect(machine.config).toMatchObject({
       type: 'FSA',
       statePrefix: 'q',
-      color: 'orange'
+      color: 'orange',
+      orOperator: '|'
     })
   })
 
@@ -116,7 +117,8 @@ describe('Import a PDA', function () {
     expect(machine.config).toMatchObject({
       type: 'PDA',
       statePrefix: 'q',
-      color: 'red'
+      color: 'red',
+      orOperator: '|'
     })
   })
 
@@ -153,7 +155,8 @@ describe('Import a TM', () => {
     expect(machine.config).toMatchObject({
       type: 'TM',
       statePrefix: 'q',
-      color: 'purple'
+      color: 'purple',
+      orOperator: '|'
     })
   })
 

--- a/packages/simulation/src/TMSearch.ts
+++ b/packages/simulation/src/TMSearch.ts
@@ -51,7 +51,7 @@ export class TMGraph extends Graph<TMState, TMAutomataTransition> {
       if (nextTape.pointer < 0) {
         nextTape = { pointer: 0, trace: ['', ...nextTape.trace] }
       }
-      if (transition.read === symbol) {
+      if (transition.read.includes(symbol)) {
         const graphState = new TMState(
           nextState.id,
           nextState.isFinal,

--- a/packages/simulation/src/utils.ts
+++ b/packages/simulation/src/utils.ts
@@ -46,13 +46,10 @@ export const expandTransitions = <T extends BaseAutomataTransition>(transitions:
 }
 
 /**
- * Performs any expansions needed for a graph (i.e. expands any transitions if its a FSA/PDA graph)
+ * Performs any expansions needed for a graph
  */
 export const expandGraph = <T extends ProjectGraph>(graph: T): T => {
-  if (['FSA', 'PDA'].includes(graph.projectType)) {
-    return { ...graph, transitions: expandTransitions(graph.transitions) }
-  }
-  return graph
+  return { ...graph, transitions: expandTransitions(graph.transitions) }
 }
 
 /**
@@ -111,9 +108,7 @@ export function buildProblem <M extends ProjectGraph> (graph: M, input: string):
   return new GraphType(
     initialNode,
     states,
-    // Only FSA and PDA graphs need to have transitions expanded
-    // This should've been done by the frontend, but we do it here just encase
-    (graph.projectType === 'TM' ? graph.transitions : expandTransitions(graph.transitions)) as T[]
+    expandTransitions(graph.transitions) as T[]
   )
 }
 

--- a/packages/simulation/tests/graphs/a2b2a.json
+++ b/packages/simulation/tests/graphs/a2b2a.json
@@ -96,6 +96,7 @@
     "type": "TM",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "purple"
+    "color": "purple",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/abba.json
+++ b/packages/simulation/tests/graphs/abba.json
@@ -78,6 +78,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/bepsi.json
+++ b/packages/simulation/tests/graphs/bepsi.json
@@ -66,6 +66,7 @@
     "type": "TM",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "purple"
+    "color": "purple",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertHarderConversion.json
+++ b/packages/simulation/tests/graphs/convertHarderConversion.json
@@ -72,6 +72,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertHarderConversionDFA.json
+++ b/packages/simulation/tests/graphs/convertHarderConversionDFA.json
@@ -120,6 +120,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertInitialNotAtStart.json
+++ b/packages/simulation/tests/graphs/convertInitialNotAtStart.json
@@ -66,6 +66,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertInitialNotAtStartDFA.json
+++ b/packages/simulation/tests/graphs/convertInitialNotAtStartDFA.json
@@ -64,6 +64,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertMultipleFinal.json
+++ b/packages/simulation/tests/graphs/convertMultipleFinal.json
@@ -66,6 +66,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertMultipleFinalDFA.json
+++ b/packages/simulation/tests/graphs/convertMultipleFinalDFA.json
@@ -64,6 +64,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertSimpleConversion.json
+++ b/packages/simulation/tests/graphs/convertSimpleConversion.json
@@ -66,6 +66,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertSimpleConversionDFA.json
+++ b/packages/simulation/tests/graphs/convertSimpleConversionDFA.json
@@ -64,6 +64,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertSingleTrapState.json
+++ b/packages/simulation/tests/graphs/convertSingleTrapState.json
@@ -84,6 +84,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/convertSingleTrapStateDFA.json
+++ b/packages/simulation/tests/graphs/convertSingleTrapStateDFA.json
@@ -221,6 +221,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/dib-end-lambda.json
+++ b/packages/simulation/tests/graphs/dib-end-lambda.json
@@ -79,6 +79,7 @@
     "statePrefix": "q",
     "acceptanceCriteria": "both",
     "color": "",
-    "playbackInterval": 1000
+    "playbackInterval": 1000,
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/dib-multipath.json
+++ b/packages/simulation/tests/graphs/dib-multipath.json
@@ -26,5 +26,6 @@
     "version": "0.0.1",
     "automatariumVersion": "0.0.1"
   },
-  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000 }
+  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "",
+    "orOperator": "|", "playbackInterval": 1000 }
 }

--- a/packages/simulation/tests/graphs/dib-odd-i.json
+++ b/packages/simulation/tests/graphs/dib-odd-i.json
@@ -23,5 +23,6 @@
     "version": "0.0.1",
     "automatariumVersion": "0.0.1"
   },
-  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000 }
+  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "",
+    "orOperator": "|", "playbackInterval": 1000 }
 }

--- a/packages/simulation/tests/graphs/dib-split-join.json
+++ b/packages/simulation/tests/graphs/dib-split-join.json
@@ -25,5 +25,6 @@
     "version": "0.0.1",
     "automatariumVersion": "0.0.1"
   },
-  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000 }
+  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "",
+    "orOperator": "|", "playbackInterval": 1000 }
 }

--- a/packages/simulation/tests/graphs/dib.json
+++ b/packages/simulation/tests/graphs/dib.json
@@ -22,5 +22,6 @@
     "version": "0.0.1",
     "automatariumVersion": "0.0.1"
   },
-  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000 }
+  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "",
+    "orOperator": "|", "playbackInterval": 1000 }
 }

--- a/packages/simulation/tests/graphs/dib_dip-even-p.json
+++ b/packages/simulation/tests/graphs/dib_dip-even-p.json
@@ -29,5 +29,6 @@
     "version": "0.0.1",
     "automatariumVersion": "0.0.1"
   },
-  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000 }
+  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000,
+    "orOperator": "|" }
 }

--- a/packages/simulation/tests/graphs/dib_dip-lambdaloop.json
+++ b/packages/simulation/tests/graphs/dib_dip-lambdaloop.json
@@ -29,5 +29,6 @@
     "version": "0.0.1",
     "automatariumVersion": "0.0.1"
   },
-  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000 }
+  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000,
+    "orOperator": "|" }
 }

--- a/packages/simulation/tests/graphs/dib_dip-odd-p.json
+++ b/packages/simulation/tests/graphs/dib_dip-odd-p.json
@@ -27,5 +27,6 @@
     "version": "0.0.1",
     "automatariumVersion": "0.0.1"
   },
-  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", "playbackInterval": 1000 }
+  "config": { "type": "FSA", "statePrefix": "q", "acceptanceCriteria": "both", "color": "", 
+    "orOperator": "|",  "playbackInterval": 1000 }
 }

--- a/packages/simulation/tests/graphs/disconnected.json
+++ b/packages/simulation/tests/graphs/disconnected.json
@@ -60,6 +60,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/evenAs.json
+++ b/packages/simulation/tests/graphs/evenAs.json
@@ -60,6 +60,7 @@
     "type": "PDA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "red"
+    "color": "red",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/highSort.json
+++ b/packages/simulation/tests/graphs/highSort.json
@@ -55,6 +55,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/infiniteLoop.json
+++ b/packages/simulation/tests/graphs/infiniteLoop.json
@@ -55,6 +55,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/infiniteLoopDFA.json
+++ b/packages/simulation/tests/graphs/infiniteLoopDFA.json
@@ -51,6 +51,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/lambda-only.json
+++ b/packages/simulation/tests/graphs/lambda-only.json
@@ -8,7 +8,8 @@
     "statePrefix": "q",
     "acceptanceCriteria": "both",
     "color": "",
-    "playbackInterval": 1000
+    "playbackInterval": 1000,
+    "orOperator": "|"
   },
   "initialState": 0,
   "meta": {

--- a/packages/simulation/tests/graphs/shuffleLeft.json
+++ b/packages/simulation/tests/graphs/shuffleLeft.json
@@ -52,6 +52,7 @@
     "type": "TM",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "purple"
+    "color": "purple",
+    "orOperator": "|"
   }
 }

--- a/packages/simulation/tests/graphs/spiggy.json
+++ b/packages/simulation/tests/graphs/spiggy.json
@@ -156,6 +156,7 @@
     "type": "FSA",
     "statePrefix": "q",
     "acceptanceCriteria": "both",
-    "color": "orange"
+    "color": "orange",
+    "orOperator": "|"
   }
 }


### PR DESCRIPTION
Closes #412 and #404 

- When a user enters a sequence of characters in the read field and presses enter, OR operators are inserted between each character ('abc' is now displayed as 'a | b | c')
- Enables multiple read inputs per transition for TMs, ensuring uniformity and consistency when working with different automata types
- Introduces a default OR operator which users can customise via the File Options menu
- Patches misaligned trace tape bubble

<img width="507" alt="Screen Shot 2023-09-23 at 14 07 57" src="https://github.com/automatarium/automatarium/assets/113315517/31caed79-d35b-4c39-925e-815b3388d555">

<img width="361" alt="Screen Shot 2023-09-23 at 14 08 08" src="https://github.com/automatarium/automatarium/assets/113315517/8e3ec735-9fa4-4f45-987e-c7af13ee8a3e">


Currently working on a transition tutorial so people know about all of the unique things Automatarium can do with transitions. 

