### PR TITLE
Fix TM Tape Stretching Components

### DIFF
--- a/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
+++ b/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
@@ -61,7 +61,7 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
       // Pointer is at the midpoint so calc the number of cells to get
       const halfFit = Math.ceil(maxTapeLength / 2)
 
-      const canSeeStart = pointer - startOffset < halfFit
+      const canSeeStart = pointer - startOffset <= halfFit
       const canSeeEnd = trace.length - pointer < halfFit + endOffset
 
       const start = canSeeStart ? 0 : pointer - halfFit - startOffset

--- a/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
+++ b/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
@@ -31,7 +31,7 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
       setTapeTrace(newTrace)
       setEffectiveEnd(newEnd)
       setInTransition(false)
-    }, 200)
+    }, 20)
   }
   // INCREASE THE POINTER, WAIT THEN UPDATE THE TAPE
 
@@ -61,7 +61,7 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
       const start = canSeeStart ? 0 : pointer - halfFit - startOffset
       const end = canSeeEnd ? trace.length : halfFit + pointer + endOffset
 
-      const right = lastPointer <= pointer 
+      const right = lastPointer <= pointer
       setLastPointer(pointer)
       setEffectiveIndex(pointer - start)
       if (!canSeeStart && !canSeeEnd) {

--- a/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
+++ b/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
@@ -21,6 +21,7 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
   const [red, setRed] = useState(false)
   const [boxWidth, setBoxWidth] = useState(900)
   const [tapeTrace, setTapeTrace] = useState(trace)
+  const [effectiveIndex, setEffectiveIndex] = useState(0)
 
   const tapeRef = useRef<HTMLDivElement>()
 
@@ -46,16 +47,18 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
    * end = If trace.length - pointer < BBFit/2 then trace.length - 1
    */
   useEffect(() => {
-    const maxTapeLength = Math.floor(boxWidth / 35) - 3
+    const maxTapeLength = Math.floor(boxWidth / 35) - 5
     console.log(`Culled: ${tapeTrace.length} Full: ${trace.length} Max: ${maxTapeLength}`)
     if (trace.length > maxTapeLength) {
-      const halfFit = Math.floor(maxTapeLength / 2)
-      const start = pointer > halfFit ? pointer - halfFit : 0
-      const end = trace.length - pointer < halfFit + 3 ? trace.length - 1 : halfFit + pointer + 3
+      const halfFit = Math.ceil(maxTapeLength / 2)
+      const start = pointer - 2 > halfFit ? pointer - halfFit - 2 : 0
+      const end = trace.length - pointer < halfFit + 3 ? trace.length : halfFit + pointer + 3
       console.log(`${pointer} => ${start}, ${end}`)
       setTapeTrace(trace.slice(start, end))
+      setEffectiveIndex(pointer - start)
     } else {
       setTapeTrace(trace)
+      setEffectiveIndex(pointer)
     }
   }, [boxWidth, pointer, trace])
 
@@ -68,7 +71,7 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
             <div ref={tapeRef}>
                 <Pointer />
                 <TickerTapeContainer>
-                    <TickerTape $index={pointer} $tapeLength={tapeTrace.length} >
+                    <TickerTape $index={effectiveIndex} $tapeLength={tapeTrace.length} >
                         <SerratedEdge />
                             {tapeTrace.map((symbol, i) => <TickerTapeCell key={i}>
                                 {symbol}

--- a/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
+++ b/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
@@ -22,6 +22,7 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
   const [boxWidth, setBoxWidth] = useState(900)
   const [tapeTrace, setTapeTrace] = useState(trace)
   const [effectiveIndex, setEffectiveIndex] = useState(0)
+  const [effectiveEnd, setEffectiveEnd] = useState(trace.length)
 
   const tapeRef = useRef<HTMLDivElement>()
 
@@ -53,12 +54,14 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
       const halfFit = Math.ceil(maxTapeLength / 2)
       const start = pointer - 2 > halfFit ? pointer - halfFit - 2 : 0
       const end = trace.length - pointer < halfFit + 3 ? trace.length : halfFit + pointer + 3
-      console.log(`${pointer} => ${start}, ${end}`)
+      console.log(`${pointer} => ${start}, ${end}; ei: ${effectiveIndex}`)
       setTapeTrace(trace.slice(start, end))
       setEffectiveIndex(pointer - start)
+      setEffectiveEnd(end)
     } else {
       setTapeTrace(trace)
       setEffectiveIndex(pointer)
+      setEffectiveEnd(trace.length)
     }
   }, [boxWidth, pointer, trace])
 
@@ -72,11 +75,11 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
                 <Pointer />
                 <TickerTapeContainer>
                     <TickerTape $index={effectiveIndex} $tapeLength={tapeTrace.length} >
-                        <SerratedEdge />
+                        {effectiveIndex === pointer && <SerratedEdge />}
                             {tapeTrace.map((symbol, i) => <TickerTapeCell key={i}>
                                 {symbol}
                             </TickerTapeCell>)}
-                        <SerratedEdge flipped />
+                        {trace.length === effectiveEnd && <SerratedEdge flipped />}
                     </TickerTape>
                 </TickerTapeContainer>
             </div>

--- a/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
+++ b/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
@@ -26,7 +26,7 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
   const updateWidth = useCallback(() => {
     // Magic numbers come from the size of toolbar, min size of canvas and size of side panel
     const minSize = 398 + 760 + 64
-    const usableWidth = window.innerWidth < minSize ? 760 : window.innerWidth - 398 + 64
+    const usableWidth = window.innerWidth < minSize ? 760 : window.innerWidth - 398 - 64
     setBoxWidth(usableWidth)
   }, [window.innerWidth])
 
@@ -36,28 +36,19 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
     return () => window.removeEventListener('resize', updateWidth)
   }, [])
 
-  /**
-   * Number that can fit into BB, BBFit = bbWidth / 35
-   * If at the start we have slice(0, BBFit/2)
-   * If at the end we have slice(trace.length - BBFit/2, trace.length - 1)
-   * start = If pointer > BBFit/2 then pointer - BBFit/2 else pointer
-   * end = If trace.length - pointer < BBFit/2 then trace.length - 1
-   */
   useEffect(() => {
-    const offset = 5
+    const offset = 2
     const endOffset = 2
     const startOffset = 1
     const maxTapeLength = Math.floor(boxWidth / 35) - offset - endOffset - startOffset
     if (trace.length > maxTapeLength) {
       const halfFit = Math.ceil(maxTapeLength / 2)
-      const start = (
-        pointer - startOffset > halfFit
-          ? pointer - halfFit - startOffset
-          : 0)
-      const end = (
-        trace.length - pointer < halfFit + endOffset
-          ? trace.length
-          : halfFit + pointer + endOffset)
+
+      const canSeeStart = pointer - startOffset < halfFit
+      const canSeeEnd = trace.length - pointer < halfFit + endOffset
+      const start = canSeeStart ? 0 : pointer - halfFit - startOffset
+      const end = canSeeEnd ? trace.length : halfFit + pointer + endOffset
+
       setTapeTrace(trace.slice(start, end))
       setEffectiveIndex(pointer - start)
       setEffectiveEnd(end)

--- a/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
+++ b/frontend/src/components/TMTraceStepWindow/TMTraceStepWindow.tsx
@@ -84,20 +84,20 @@ const TMTraceStepWindow = ({ trace, pointer, accepted, isEnd }: TMTraceStepWindo
     setRed(isEnd && !accepted)
   }, [accepted, isEnd])
   return (
-        <Container style={{ background: green ? '#689540' : red ? '#d30303' : 'var(--toolbar)' }} >
-            <div>
-                <Pointer />
-                <TickerTapeContainer>
-                    <TickerTape $index={effectiveIndex} $tapeLength={tapeTrace.length} $inTransition={inTransition}>
-                        {effectiveIndex === pointer && <SerratedEdge />}
-                            {tapeTrace.map((symbol, i) => <TickerTapeCell key={i}>
-                                {symbol}
-                            </TickerTapeCell>)}
-                        {trace.length === effectiveEnd && <SerratedEdge flipped />}
-                    </TickerTape>
-                </TickerTapeContainer>
-            </div>
-        </Container>
+    <Container style={{ background: green ? '#689540' : red ? '#d30303' : 'var(--toolbar)' }} >
+      <div>
+        <Pointer />
+        <TickerTapeContainer>
+          <TickerTape $index={effectiveIndex} $tapeLength={tapeTrace.length} $inTransition={inTransition}>
+            {effectiveIndex === pointer && <SerratedEdge />}
+              {tapeTrace.map((symbol, i) => <TickerTapeCell key={i}>
+                {symbol}
+              </TickerTapeCell>)}
+            {trace.length === effectiveEnd && <SerratedEdge flipped />}
+          </TickerTape>
+        </TickerTapeContainer>
+      </div>
+    </Container>
   )
 }
 

--- a/frontend/src/components/TMTraceStepWindow/tmTraceStepWindowStyle.ts
+++ b/frontend/src/components/TMTraceStepWindow/tmTraceStepWindowStyle.ts
@@ -23,6 +23,7 @@ export const TickerTapeContainer = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: center;
+  align-self:start;
 `
 
 // Involves spooky math function for transform. Pen and paper type stuff.

--- a/frontend/src/components/TMTraceStepWindow/tmTraceStepWindowStyle.ts
+++ b/frontend/src/components/TMTraceStepWindow/tmTraceStepWindowStyle.ts
@@ -27,12 +27,14 @@ export const TickerTapeContainer = styled('div')`
 `
 
 // Involves spooky math function for transform. Pen and paper type stuff.
-export const TickerTape = styled('div')<{$tapeLength: number, $index: number}>`
+export const TickerTape = styled('div')<{$tapeLength: number, $index: number, $inTransition: boolean}>`
   display: flex;
   flex-direction: row;
   transform: translateX(calc((${p => p.$tapeLength - 1}/2) * var(--cell-width) + ${p => -p.$index} * var(--cell-width)));
   width: max-content;
-  transition: transform .2s;
+  ${p => p.$inTransition && `
+    transition: transform .2s;
+  `}
 `
 
 export const TickerTapeCell = styled('span')`


### PR DESCRIPTION
Closes #440.

Issue was caused by the whole tape taking space at all times and the animation being handled by a CSS transition (putting `margin-left: 1000px` on an element will get a similar effect).

This is a bandaid fix on the problem so that the TM tape for longer input strings is not obnoxious. A rewrite/redesign of the TM tape component might be needed to fix it completely. The fix will cull the size of the rendered tape so that it won't stretch the middle components, and maintain the animation (but janky) to keep up the appearance of the tape moving.

Alternative would be to make all the tape's parents not stretch but I couldn't for the life of me get it working (and you will still have the overflow problem).