### PR TITLE
Template thumbnails

### DIFF
--- a/frontend/src/components/EditorPanel/EditorPanel.tsx
+++ b/frontend/src/components/EditorPanel/EditorPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import StateCircle from '../StateCircle/StateCircle'
+import StateCircle from '/src/components/StateCircle/StateCircle'
 import { GraphContent, GraphView, SelectionBox, TransitionSet, ContextMenus, InputDialogs, InputTransitionGroup } from '/src/components'
 import {
   useEvent,
@@ -17,7 +17,8 @@ import {
 import { SelectionEvent } from '/src/hooks/useResourceSelection'
 import { useSelectionStore, useTemplateStore } from '/src/stores'
 import { CommentEventData, EdgeEventData, StateEventData, TransitionEventData } from '/src/hooks/useEvent'
-import TemplateGhost from '../Template/TemplateGhost'
+import TemplateGhost from '/src/components/Template/TemplateGhost'
+import SelectedGraphContent from '/src/components/GraphContent/SelectedGraphContent'
 
 const EditorPanel = () => {
   const [renderSelection, setRenderSelection] = useState(false)
@@ -112,6 +113,9 @@ const EditorPanel = () => {
 
   useEvent('selectiongraph:show', () => {
     setRenderSelection(true)
+    setTimeout(() => {
+      // dispatch event to create template image to thumbnail store
+    }, 50)
   })
 
   useEvent('selectiongraph:hide', () => {
@@ -145,7 +149,9 @@ const EditorPanel = () => {
       <SelectionBox />
     </GraphView>
     {/** Temporarily render selected for image export */}
-    {renderSelection && <GraphView $selectedOnly={true}><></></GraphView>}
+    {renderSelection && <GraphView $selectedOnly={true}>
+        <SelectedGraphContent />
+      </GraphView>}
     <ContextMenus />
     <InputDialogs />
     <InputTransitionGroup />

--- a/frontend/src/components/EditorPanel/EditorPanel.tsx
+++ b/frontend/src/components/EditorPanel/EditorPanel.tsx
@@ -1,24 +1,25 @@
 import { useState } from 'react'
+import { ContextMenus, GraphContent, GraphView, InputDialogs, InputTransitionGroup, SelectionBox, TransitionSet } from '/src/components'
+import SelectedGraphContent from '/src/components/GraphContent/SelectedGraphContent'
 import StateCircle from '/src/components/StateCircle/StateCircle'
-import { GraphContent, GraphView, SelectionBox, TransitionSet, ContextMenus, InputDialogs, InputTransitionGroup } from '/src/components'
+import TemplateGhost from '/src/components/Template/TemplateGhost'
 import {
-  useEvent,
-  useStateDragging,
+  useCommentCreation,
   useCommentDragging,
   useCommentSelection,
+  useContextMenus,
+  useEvent,
   useStateCreation,
-  useTransitionCreation,
-  useCommentCreation,
+  useStateDragging,
   useStateSelection,
-  useTransitionSelection,
   useTemplateInsert,
-  useContextMenus
+  useTransitionCreation,
+  useTransitionSelection
 } from '/src/hooks'
+import { CommentEventData, EdgeEventData, StateEventData, TransitionEventData } from '/src/hooks/useEvent'
 import { SelectionEvent } from '/src/hooks/useResourceSelection'
 import { useSelectionStore, useTemplateStore } from '/src/stores'
-import { CommentEventData, EdgeEventData, StateEventData, TransitionEventData } from '/src/hooks/useEvent'
-import TemplateGhost from '/src/components/Template/TemplateGhost'
-import SelectedGraphContent from '/src/components/GraphContent/SelectedGraphContent'
+import { dispatchCustomEvent } from '/src/util/events'
 
 const EditorPanel = () => {
   const [renderSelection, setRenderSelection] = useState(false)
@@ -111,14 +112,12 @@ const EditorPanel = () => {
     setTransitions(e.detail.transitions.map(t => t.id))
   })
 
-  useEvent('selectiongraph:show', () => {
+  useEvent('createTemplateThumbnail', (e) => {
     setRenderSelection(true)
-    setTimeout(() => {
-      // dispatch event to create template image to thumbnail store
-    }, 50)
+    dispatchCustomEvent('storeTemplateThumbnail', e.detail)
   })
 
-  useEvent('selectiongraph:hide', () => {
+  useEvent('selectionGraph:hide', () => {
     setRenderSelection(false)
   })
 

--- a/frontend/src/components/EditorPanel/EditorPanel.tsx
+++ b/frontend/src/components/EditorPanel/EditorPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import StateCircle from '../StateCircle/StateCircle'
 import { GraphContent, GraphView, SelectionBox, TransitionSet, ContextMenus, InputDialogs, InputTransitionGroup } from '/src/components'
 import {
@@ -19,6 +20,8 @@ import { CommentEventData, EdgeEventData, StateEventData, TransitionEventData } 
 import TemplateGhost from '../Template/TemplateGhost'
 
 const EditorPanel = () => {
+  const [renderSelection, setRenderSelection] = useState(false)
+
   // Interactivity hooks
   const { select: selectState } = useStateSelection()
   const { select: selectTransition } = useTransitionSelection()
@@ -107,6 +110,14 @@ const EditorPanel = () => {
     setTransitions(e.detail.transitions.map(t => t.id))
   })
 
+  useEvent('selectiongraph:show', () => {
+    setRenderSelection(true)
+  })
+
+  useEvent('selectiongraph:hide', () => {
+    setRenderSelection(false)
+  })
+
   return <>
     <GraphView>
       {/* Render in-creation transition. Since we aren't rendering text it doesn't matter what the project is */}
@@ -133,6 +144,8 @@ const EditorPanel = () => {
       {/* Render selection marquee */}
       <SelectionBox />
     </GraphView>
+    {/** Temporarily render selected for image export */}
+    {renderSelection && <GraphView $selectedOnly={true}><></></GraphView>}
     <ContextMenus />
     <InputDialogs />
     <InputTransitionGroup />

--- a/frontend/src/components/GraphContent/GraphContent.tsx
+++ b/frontend/src/components/GraphContent/GraphContent.tsx
@@ -1,9 +1,6 @@
-import groupBy from 'lodash.groupby'
-
 import { StateCircle, TransitionSet, InitialStateArrow, CommentRect } from '/src/components'
 import { useProjectStore, useSelectionStore, useSteppingStore } from '/src/stores'
-import { locateTransition, PositionedTransition } from '/src/util/states'
-import { AutomataTransition } from '/src/types/ProjectTypes'
+import { getGroupedTransitions } from './utils'
 
 const GraphContent = () => {
   const project = useProjectStore(s => s.project)
@@ -16,14 +13,7 @@ const GraphContent = () => {
   const comments = project?.comments ?? []
   const initialState = project?.initialState
 
-  // Group up transitions by the start and end nodes
-  // We sort the IDs in the pair to make direction not impact grouping
-  const groupedTransitions = Object.values(groupBy(transitions, t => [t.from, t.to].sort((a, b) => b - a))) as AutomataTransition[][]
-  const locatedTransitions = groupedTransitions
-    .map(transitions => transitions
-      .map((t): PositionedTransition => locateTransition(t, states)) // Resolve location of transition states
-      // Sort by direction. If the x coordinates are the same then compare by Y axis
-      .sort((t1, t2) => (t2.from.x === t1.from.x ? t2.from.y < t1.from.y : t2.from.x < t1.from.x) ? 1 : -1))
+  const locatedTransitions = getGroupedTransitions(transitions, states)
 
   return <>
     {/* Render arrow on initial state */}

--- a/frontend/src/components/GraphContent/SelectedGraphContent.tsx
+++ b/frontend/src/components/GraphContent/SelectedGraphContent.tsx
@@ -1,17 +1,20 @@
+import { useMemo } from 'react'
+import { getGroupedTransitions } from './utils'
+import CommentRect from '/src/components/CommentRect/CommentRect'
 import StateCircle from '/src/components/StateCircle/StateCircle'
 import TransitionSet from '/src/components/TransitionSet/TransitionSet'
-import { getGroupedTransitions } from './utils'
 import { useProjectStore, useSelectionStore } from '/src/stores'
-import { useMemo } from 'react'
 
 const SelectedGraphContent = () => {
   const project = useProjectStore(s => s.project)
-  const { transitions, states } = project ?? {}
+  const { transitions, states, comments } = project ?? {}
   const selectedTransitionIds = useSelectionStore(s => s.selectedTransitions)
   const selectedStateIds = useSelectionStore(s => s.selectedStates)
+  const selectedCommentsIds = useSelectionStore(s => s.selectedComments)
 
   const selectedTransitions = useMemo(() => transitions.filter(t => selectedTransitionIds.includes(t.id)), [transitions])
   const selectedStates = useMemo(() => states.filter(s => selectedStateIds.includes(s.id)), [states])
+  const selectedComments = useMemo(() => comments.filter(c => selectedCommentsIds.includes(c.id)), [comments, selectedCommentsIds])
 
   const locatedTransitions = useMemo(() =>
     getGroupedTransitions(selectedTransitions, selectedStates),
@@ -19,14 +22,14 @@ const SelectedGraphContent = () => {
 
   return <>
     {/* Render all sets of edges */}
-    {locatedTransitions.map((transitions, i) => <TransitionSet
+    {!!locatedTransitions && locatedTransitions.map((transitions, i) => <TransitionSet
       transitions={transitions}
       isTemplate={true}
       key={i}
     />)}
 
     {/* Render all states */}
-    {selectedStates.map(s => <StateCircle
+    {!!selectedStates && selectedStates.map(s => <StateCircle
       key={s.id}
       id={s.id}
       name={s.name}
@@ -36,6 +39,15 @@ const SelectedGraphContent = () => {
       isFinal={s.isFinal}
       selected={false}
       stepped={false}
+    />)}
+
+    {/* Render all comments */}
+    {!!selectedComments && selectedComments.map(c => <CommentRect
+      key={c.id}
+      id={c.id}
+      x={c.x}
+      y={c.y}
+      text={c.text}
     />)}
   </>
 }

--- a/frontend/src/components/GraphContent/SelectedGraphContent.tsx
+++ b/frontend/src/components/GraphContent/SelectedGraphContent.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from 'react'
 import { getGroupedTransitions } from './utils'
 import CommentRect from '/src/components/CommentRect/CommentRect'
 import StateCircle from '/src/components/StateCircle/StateCircle'
@@ -12,13 +11,11 @@ const SelectedGraphContent = () => {
   const selectedStateIds = useSelectionStore(s => s.selectedStates)
   const selectedCommentsIds = useSelectionStore(s => s.selectedComments)
 
-  const selectedTransitions = useMemo(() => transitions.filter(t => selectedTransitionIds.includes(t.id)), [transitions])
-  const selectedStates = useMemo(() => states.filter(s => selectedStateIds.includes(s.id)), [states])
-  const selectedComments = useMemo(() => comments.filter(c => selectedCommentsIds.includes(c.id)), [comments, selectedCommentsIds])
+  const selectedTransitions = transitions.filter(t => selectedTransitionIds.includes(t.id))
+  const selectedStates = states.filter(s => selectedStateIds.includes(s.id))
+  const selectedComments = comments.filter(c => selectedCommentsIds.includes(c.id))
 
-  const locatedTransitions = useMemo(() =>
-    getGroupedTransitions(selectedTransitions, selectedStates),
-  [selectedStateIds, selectedTransitionIds])
+  const locatedTransitions = getGroupedTransitions(selectedTransitions, selectedStates)
 
   return <>
     {/* Render all sets of edges */}

--- a/frontend/src/components/GraphContent/SelectedGraphContent.tsx
+++ b/frontend/src/components/GraphContent/SelectedGraphContent.tsx
@@ -1,0 +1,39 @@
+import StateCircle from '/src/components/StateCircle/StateCircle'
+import TransitionSet from '/src/components/TransitionSet/TransitionSet'
+import { getGroupedTransitions } from './utils'
+import { useProjectStore, useSelectionStore } from '/src/stores'
+
+const SelectedGraphContent = () => {
+  const project = useProjectStore(s => s.project)
+  const { transitions, states } = project ?? {}
+  const selectedTransitionIds = useSelectionStore(s => s.selectedTransitions)
+  const selectedStateIds = useSelectionStore(s => s.selectedStates)
+
+  const selectedTransitions = transitions.filter(t => selectedTransitionIds.includes(t.id))
+  const selectedStates = states.filter(s => selectedStateIds.includes(s.id))
+
+  const locatedTransitions = getGroupedTransitions(selectedTransitions, selectedStates)
+
+  return <>
+    {/* Render all sets of edges */}
+    {locatedTransitions.map((transitions, i) => <TransitionSet
+      transitions={transitions}
+      key={i}
+    />)}
+
+    {/* Render all states */}
+    {selectedStates.map(s => <StateCircle
+      key={s.id}
+      id={s.id}
+      name={s.name}
+      label={s.label}
+      cx={s.x}
+      cy={s.y}
+      isFinal={s.isFinal}
+      selected={false}
+      stepped={false}
+    />)}
+  </>
+}
+
+export default SelectedGraphContent

--- a/frontend/src/components/GraphContent/SelectedGraphContent.tsx
+++ b/frontend/src/components/GraphContent/SelectedGraphContent.tsx
@@ -2,6 +2,7 @@ import StateCircle from '/src/components/StateCircle/StateCircle'
 import TransitionSet from '/src/components/TransitionSet/TransitionSet'
 import { getGroupedTransitions } from './utils'
 import { useProjectStore, useSelectionStore } from '/src/stores'
+import { useMemo } from 'react'
 
 const SelectedGraphContent = () => {
   const project = useProjectStore(s => s.project)
@@ -9,10 +10,12 @@ const SelectedGraphContent = () => {
   const selectedTransitionIds = useSelectionStore(s => s.selectedTransitions)
   const selectedStateIds = useSelectionStore(s => s.selectedStates)
 
-  const selectedTransitions = transitions.filter(t => selectedTransitionIds.includes(t.id))
-  const selectedStates = states.filter(s => selectedStateIds.includes(s.id))
+  const selectedTransitions = useMemo(() => transitions.filter(t => selectedTransitionIds.includes(t.id)), [transitions])
+  const selectedStates = useMemo(() => states.filter(s => selectedStateIds.includes(s.id)), [states])
 
-  const locatedTransitions = getGroupedTransitions(selectedTransitions, selectedStates)
+  const locatedTransitions = useMemo(() =>
+    getGroupedTransitions(selectedTransitions, selectedStates),
+  [selectedStateIds, selectedTransitionIds])
 
   return <>
     {/* Render all sets of edges */}

--- a/frontend/src/components/GraphContent/SelectedGraphContent.tsx
+++ b/frontend/src/components/GraphContent/SelectedGraphContent.tsx
@@ -21,6 +21,7 @@ const SelectedGraphContent = () => {
     {/* Render all sets of edges */}
     {locatedTransitions.map((transitions, i) => <TransitionSet
       transitions={transitions}
+      isTemplate={true}
       key={i}
     />)}
 

--- a/frontend/src/components/GraphContent/utils.tsx
+++ b/frontend/src/components/GraphContent/utils.tsx
@@ -1,0 +1,16 @@
+import groupBy from 'lodash.groupby'
+
+import { AutomataState, AutomataTransition, BaseAutomataTransition } from '/src/types/ProjectTypes'
+import { PositionedTransition, locateTransition } from '/src/util/states'
+
+/** Group up transitions by the start and end nodes
+ *  We sort the IDs in the pair to make direction not impact grouping
+ */
+export const getGroupedTransitions = (transitions: BaseAutomataTransition[], states: AutomataState[]) => {
+  const groupedTransitions = Object.values(groupBy(transitions, t => [t.from, t.to].sort((a, b) => b - a))) as AutomataTransition[][]
+  return groupedTransitions
+    .map(transitions => transitions
+      .map((t): PositionedTransition => locateTransition(t, states)) // Resolve location of transition states
+      // Sort by direction. If the x coordinates are the same then compare by Y axis
+      .sort((t1, t2) => (t2.from.x === t1.from.x ? t2.from.y < t1.from.y : t2.from.x < t1.from.x) ? 1 : -1))
+}

--- a/frontend/src/components/GraphView/GraphView.tsx
+++ b/frontend/src/components/GraphView/GraphView.tsx
@@ -13,9 +13,10 @@ import { calculateZoomFit } from '/src/hooks/useActions'
 
 interface GraphViewProps extends HTMLAttributes<SVGElement>{
   children: ReactNode
+  $selectedOnly?: boolean
 }
 
-const GraphView = ({ children, ...props }: GraphViewProps) => {
+const GraphView = ({ children, $selectedOnly: $isTemplate = false, ...props }: GraphViewProps) => {
   const wrapperRef = useRef<HTMLDivElement>()
   const svgRef = useRef<SVGSVGElement>()
   const { position, size, scale, setViewSize, setSvgElement, screenToViewSpace } = useViewStore()
@@ -123,13 +124,14 @@ const GraphView = ({ children, ...props }: GraphViewProps) => {
   const gridVisible = usePreferencesStore(state => state.preferences.showGrid)
 
   const viewBox = `${position.x} ${position.y} ${scale * size.width} ${scale * size.height}`
+  const svgId = $isTemplate ? 'selected-graph' : 'automatarium-graph'
   return (
     <Wrapper ref={wrapperRef} id='editor-panel-wrapper'>
       <Svg
         version="1.1"
         xmlns="http://www.w3.org/2000/svg"
         xmlnsXlink="http://www.w3.org/1999/xlink"
-        id="automatarium-graph"
+        id={svgId}
 
         onContextMenu={e => e.preventDefault()}
         viewBox={viewBox}

--- a/frontend/src/components/GraphView/GraphView.tsx
+++ b/frontend/src/components/GraphView/GraphView.tsx
@@ -76,7 +76,7 @@ const GraphView = ({ children, $selectedOnly: $isTemplate = false, ...props }: G
   }, [])
 
   // Keep track of resizes
-  useEffect(() => {
+  !$isTemplate && useEffect(() => {
     if (svgRef.current) {
       // Update reference
       setSvgElement(svgRef.current)
@@ -101,7 +101,7 @@ const GraphView = ({ children, $selectedOnly: $isTemplate = false, ...props }: G
   }, [svgRef.current])
 
   // Add a resize observer to the wrapper div
-  useEffect(() => {
+  !$isTemplate && useEffect(() => {
     if (wrapperRef.current) {
       const resizeObserver = new ResizeObserver(onContainerResize)
       resizeObserver.observe(wrapperRef.current)

--- a/frontend/src/components/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard/ProjectCard.tsx
@@ -3,7 +3,7 @@ import relativeTime from 'dayjs/plugin/relativeTime'
 
 import { Logo } from '/src/components'
 
-import { MoreVertical } from 'lucide-react'
+import { MoreVertical, Trash } from 'lucide-react'
 import { ButtonHTMLAttributes, Ref } from 'react'
 import { CardContainer, CardDetail, CardImage, SelectedTemplateOverlay, TitleAndKebab, TypeBadge } from './projectCardStyle'
 import { ProjectType } from '/src/types/ProjectTypes'
@@ -22,6 +22,7 @@ type ProjectCardProps = {
   onClick?: ButtonHTMLAttributes<HTMLButtonElement>['onClick']
   $kebabClick?: ButtonHTMLAttributes<HTMLAnchorElement>['onClick'],
   $kebabRef?: Ref<HTMLAnchorElement>
+  $deleteTemplate?: ButtonHTMLAttributes<HTMLAnchorElement>['onClick']
   disabled?: boolean,
 }
 
@@ -37,11 +38,17 @@ const ProjectCard = ({ name, type, date, image, isSelectedTemplate = false, ...p
     <CardDetail>
       <TitleAndKebab>
         <strong>{name}</strong>
-        <div>
-          <a onClick={props.$kebabClick} ref={props.$kebabRef}>
-            <MoreVertical/>
-          </a>
-        </div>
+        {props.$istemplate
+          ? <div>
+            <a onClick={props.$deleteTemplate}>
+              <Trash />
+            </a>
+          </div>
+          : <div>
+            <a onClick={props.$kebabClick} ref={props.$kebabRef}>
+              <MoreVertical/>
+            </a>
+          </div>}
       </TitleAndKebab>
       {date && <span>{date instanceof dayjs ? dayjs().to(date) : date as string}</span>}
     </CardDetail>

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -50,14 +50,14 @@ const Templates = () => {
     const templateName = templateNameInput
     // Show errors
     if (selectedStatesIds.length < 1) {
-      setError('Please select states and/or transitions before clicking "Add".')
+      setError('Please select at least one state before clicking "Add".')
       return
     }
     if (selectedTransitionsIds.length > 0) {
       const { transitions } = useProjectStore.getState()?.project ?? { transitions: [] }
       const selectedTransitions = transitions.filter(t => selectedTransitionsIds.includes(t.id))
       if (!selectedTransitions.every(t => selectedStatesIds.includes(t.from) && selectedStatesIds.includes(t.to))) {
-        setError('Transitions require a from and to state to attach to')
+        setError('Transitions must include its connected states')
         return
       }
     }

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -56,7 +56,7 @@ const Templates = () => {
     if (selectedTransitionsIds.length > 0) {
       const { transitions } = useProjectStore.getState()?.project ?? { transitions: [] }
       const selectedTransitions = transitions.filter(t => selectedTransitionsIds.includes(t.id))
-      if (!selectedTransitions.some(t => selectedStatesIds.includes(t.from) && selectedStatesIds.includes(t.to))) {
+      if (!selectedTransitions.every(t => selectedStatesIds.includes(t.from) && selectedStatesIds.includes(t.to))) {
         setError('Transitions require a from and to state to attach to')
         return
       }
@@ -79,7 +79,7 @@ const Templates = () => {
     addTemplate(newTemplate)
     setTemplateNameInput('')
     setError('')
-  }, [selectedTransitionsIds, selectedStatesIds, selectedCommentsIds])
+  }, [selectedTransitionsIds, selectedStatesIds, selectedCommentsIds, templateNameInput, templates])
 
   return <>
     <SectionLabel>Create a Template</SectionLabel>

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -24,7 +24,6 @@ const Templates = () => {
   const templates = (useTemplatesStore(s => s.templates)).filter(temp => temp.projectType === project.projectType)
   const addTemplate = useTemplatesStore(s => s.upsertTemplate)
   const setTemplate = useTemplateStore(s => s.setTemplate)
-  const deleteTemplate = useTemplatesStore(s => s.deleteTemplate)
   const template = useTemplateStore(s => s.template)
   const selectedStatesIds = useSelectionStore(s => s.selectedStates)
   const selectedCommentsIds = useSelectionStore(s => s.selectedComments)
@@ -110,7 +109,11 @@ const Templates = () => {
                 $istemplate={true}
                 $deleteTemplate={e => {
                   e.stopPropagation()
-                  deleteTemplate(temp._id)
+                  dispatchCustomEvent('modal:editorConfirmation', {
+                    title: 'Delete Template?',
+                    description: `This will permanently remove ${temp.name} from your computer.`,
+                    tid: temp._id
+                  })
                 }}
                 isSelectedTemplate={template && template._id === temp._id}
                 onClick={() => pickTemplate(temp._id)}

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs'
 
 import { Wrapper } from './templatesStyle'
 import { Description } from '/src/components/Preference/preferenceStyle'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { Template } from '/src/types/ProjectTypes'
 import { TEMPLATE_THUMBNAIL_WIDTH } from '/src/config/rendering'
 import { WarningLabel } from '../TestingLab/testingLabStyle'
@@ -21,7 +21,8 @@ export const stopTemplateInsert = (setTemplate: (template: Template) => void, se
 
 const Templates = () => {
   const project = useProjectStore(s => s.project)
-  const templates = (useTemplatesStore(s => s.templates)).filter(temp => temp.projectType === project.projectType)
+  const templatesFromStore = useTemplatesStore(s => s.templates)
+  const templates = useMemo(() => templatesFromStore.filter(temp => temp.projectType === project.projectType), [project, templatesFromStore])
   const addTemplate = useTemplatesStore(s => s.upsertTemplate)
   const setTemplate = useTemplateStore(s => s.setTemplate)
   const template = useTemplateStore(s => s.template)

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs'
 
 import { Wrapper } from './templatesStyle'
 import { Description } from '/src/components/Preference/preferenceStyle'
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Template } from '/src/types/ProjectTypes'
 import { TEMPLATE_THUMBNAIL_WIDTH } from '/src/config/rendering'
 import { WarningLabel } from '../TestingLab/testingLabStyle'
@@ -31,6 +31,7 @@ const Templates = () => {
   const setTool = useToolStore(s => s.setTool)
 
   const thumbs = useThumbnailStore(s => s.thumbnails)
+  const removeThumbnail = useThumbnailStore(s => s.removeThumbnail)
 
   const [templateNameInput, setTemplateNameInput] = useState('')
   const [error, setError] = useState('')
@@ -72,6 +73,13 @@ const Templates = () => {
     setTemplateNameInput('')
     setError('')
   }
+
+  // Remove old thumbnails
+  useEffect(() => {
+    if (templates.length) {
+      Object.keys(thumbs).forEach(id => id.startsWith('tmp') && !templates.some(p => `tmp${p._id}` === id) && removeThumbnail(`tmp${id}`))
+    }
+  }, [templates, thumbs])
 
   return <>
     <SectionLabel>Create a Template</SectionLabel>

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs'
 
 import { Wrapper } from './templatesStyle'
 import { Description } from '/src/components/Preference/preferenceStyle'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Template } from '/src/types/ProjectTypes'
 import { TEMPLATE_THUMBNAIL_WIDTH } from '/src/config/rendering'
 import { WarningLabel } from '../TestingLab/testingLabStyle'
@@ -21,8 +21,7 @@ export const stopTemplateInsert = (setTemplate: (template: Template) => void, se
 
 const Templates = () => {
   const project = useProjectStore(s => s.project)
-  const templatesFromStore = useTemplatesStore(s => s.templates)
-  const templates = useMemo(() => templatesFromStore.filter(temp => temp.projectType === project.projectType), [project, templatesFromStore])
+  const templates = useTemplatesStore(s => s.templates).filter(temp => temp.projectType === project.projectType)
   const addTemplate = useTemplatesStore(s => s.upsertTemplate)
   const setTemplate = useTemplateStore(s => s.setTemplate)
   const template = useTemplateStore(s => s.template)

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -24,6 +24,7 @@ const Templates = () => {
   const templates = (useTemplatesStore(s => s.templates)).filter(temp => temp.projectType === project.projectType)
   const addTemplate = useTemplatesStore(s => s.upsertTemplate)
   const setTemplate = useTemplateStore(s => s.setTemplate)
+  const deleteTemplate = useTemplatesStore(s => s.deleteTemplate)
   const template = useTemplateStore(s => s.template)
   const selectedStatesIds = useSelectionStore(s => s.selectedStates)
   const selectedCommentsIds = useSelectionStore(s => s.selectedComments)
@@ -107,6 +108,10 @@ const Templates = () => {
                 width={TEMPLATE_THUMBNAIL_WIDTH}
                 image={thumbs[`tmp${temp._id}`]}
                 $istemplate={true}
+                $deleteTemplate={e => {
+                  e.stopPropagation()
+                  deleteTemplate(temp._id)
+                }}
                 isSelectedTemplate={template && template._id === temp._id}
                 onClick={() => pickTemplate(temp._id)}
               />

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs'
 
 import { Wrapper } from './templatesStyle'
 import { Description } from '/src/components/Preference/preferenceStyle'
-import React, { useMemo, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { Template } from '/src/types/ProjectTypes'
 import { TEMPLATE_THUMBNAIL_WIDTH } from '/src/config/rendering'
 import { WarningLabel } from '../TestingLab/testingLabStyle'
@@ -47,7 +47,7 @@ const Templates = () => {
     setTool(null)
   }
 
-  const createTemplate = () => {
+  const createTemplate = useCallback(() => {
     const templateName = templateNameInput
     // Show errors
     if (selectedStatesIds.length === 0 && selectedCommentsIds.length === 0 && selectedTransitionsIds.length === 0) {
@@ -80,7 +80,7 @@ const Templates = () => {
     addTemplate(newTemplate)
     setTemplateNameInput('')
     setError('')
-  }
+  }, [selectedTransitionsIds, selectedStatesIds, selectedCommentsIds])
 
   return <>
     <SectionLabel>Create a Template</SectionLabel>

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -49,7 +49,7 @@ const Templates = () => {
   const createTemplate = useCallback(() => {
     const templateName = templateNameInput
     // Show errors
-    if (selectedStatesIds.length === 0 && selectedCommentsIds.length === 0 && selectedTransitionsIds.length === 0) {
+    if (selectedStatesIds.length < 1) {
       setError('Please select states and/or transitions before clicking "Add".')
       return
     }

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -1,4 +1,4 @@
-import { useTemplatesStore, useTemplateStore, useSelectionStore, useProjectStore, useToolStore } from '/src/stores'
+import { useTemplatesStore, useTemplateStore, useSelectionStore, useProjectStore, useToolStore, useThumbnailStore } from '/src/stores'
 import { SectionLabel, Input, Button, ProjectCard } from '/src/components'
 import { CardList } from '/src/pages/NewFile/components'
 import { selectionToCopyTemplate } from '/src/hooks/useActions'
@@ -12,6 +12,7 @@ import { Template } from '/src/types/ProjectTypes'
 import { TEMPLATE_THUMBNAIL_WIDTH } from '/src/config/rendering'
 import { WarningLabel } from '../TestingLab/testingLabStyle'
 import { Tool } from '/src/stores/useToolStore'
+import { dispatchCustomEvent } from '/src/util/events'
 
 export const stopTemplateInsert = (setTemplate: (template: Template) => void, setTool: (tool: Tool) => void) => {
   setTemplate(null)
@@ -28,6 +29,8 @@ const Templates = () => {
   const selectedCommentsIds = useSelectionStore(s => s.selectedComments)
   const selectedTransitionsIds = useSelectionStore(s => s.selectedTransitions)
   const setTool = useToolStore(s => s.setTool)
+
+  const thumbs = useThumbnailStore(s => s.thumbnails)
 
   const [templateNameInput, setTemplateNameInput] = useState('')
   const [error, setError] = useState('')
@@ -64,6 +67,7 @@ const Templates = () => {
     newTemplate._id = crypto.randomUUID()
     newTemplate.name = templateName
     newTemplate.date = new Date().getTime()
+    dispatchCustomEvent('createTemplateThumbnail', newTemplate._id)
     addTemplate(newTemplate)
     setTemplateNameInput('')
     setError('')
@@ -101,6 +105,7 @@ const Templates = () => {
                 name={temp.name}
                 date={dayjs(temp.date)}
                 width={TEMPLATE_THUMBNAIL_WIDTH}
+                image={thumbs[`tmp${temp._id}`]}
                 $istemplate={true}
                 isSelectedTemplate={template && template._id === temp._id}
                 onClick={() => pickTemplate(temp._id)}

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -7,7 +7,7 @@ import dayjs from 'dayjs'
 
 import { Wrapper } from './templatesStyle'
 import { Description } from '/src/components/Preference/preferenceStyle'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { Template } from '/src/types/ProjectTypes'
 import { TEMPLATE_THUMBNAIL_WIDTH } from '/src/config/rendering'
 import { WarningLabel } from '../TestingLab/testingLabStyle'
@@ -32,7 +32,6 @@ const Templates = () => {
   const setTool = useToolStore(s => s.setTool)
 
   const thumbs = useThumbnailStore(s => s.thumbnails)
-  const removeThumbnail = useThumbnailStore(s => s.removeThumbnail)
 
   const [templateNameInput, setTemplateNameInput] = useState('')
   const [error, setError] = useState('')
@@ -74,13 +73,6 @@ const Templates = () => {
     setTemplateNameInput('')
     setError('')
   }
-
-  // Remove old thumbnails
-  useEffect(() => {
-    if (templates.length) {
-      Object.keys(thumbs).forEach(id => id.startsWith('tmp') && !templates.some(p => `tmp${p._id}` === id) && removeThumbnail(`tmp${id}`))
-    }
-  }, [templates, thumbs])
 
   return <>
     <SectionLabel>Create a Template</SectionLabel>

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -54,6 +54,14 @@ const Templates = () => {
       setError('Please select states and/or transitions before clicking "Add".')
       return
     }
+    if (selectedTransitionsIds.length > 0) {
+      const { transitions } = useProjectStore.getState()?.project ?? { transitions: [] }
+      const selectedTransitions = transitions.filter(t => selectedTransitionsIds.includes(t.id))
+      if (!selectedTransitions.some(t => selectedStatesIds.includes(t.from) && selectedStatesIds.includes(t.to))) {
+        setError('Transitions require a from and to state to attach to')
+        return
+      }
+    }
     if (templateName === '') {
       setError('Template name cannot be empty.')
       return

--- a/frontend/src/components/Sidepanel/Sidepanel.tsx
+++ b/frontend/src/components/Sidepanel/Sidepanel.tsx
@@ -46,7 +46,7 @@ const panels: PanelItem[] = [
     element: <Options />
   },
   {
-    label: 'Templates (Beta)',
+    label: 'Templates',
     value: 'templates',
     icon: <Star />,
     element: <Templates />

--- a/frontend/src/components/Template/TemplateGhost.tsx
+++ b/frontend/src/components/Template/TemplateGhost.tsx
@@ -8,7 +8,7 @@ import { PositionedTransition, locateTransition } from '/src/util/states'
 
 const TemplateGhost = ({ template, mousePos }: {template: Template, mousePos: Coordinate}) => {
   const templateCopy = structuredClone(template)
-  moveStatesToMouse(mousePos, templateCopy.states)
+  moveStatesToMouse(mousePos, templateCopy.states, templateCopy.comments)
   // Next few lines are from GraphContent.tsx, perhaps should make this its own function?
   const groupedTransitions = Object.values(groupBy(templateCopy.transitions, t => [t.from, t.to].sort((a, b) => b - a))) as AutomataTransition[][]
   const locatedTransitions = groupedTransitions

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -51,7 +51,7 @@ const toRightOf = (a: Coordinate, b: Coordinate) => {
   return a.x === b.x ? a.y < b.y : a.x > b.x
 }
 
-const TransitionSet = ({ transitions, isGhost = false } : {transitions: PositionedTransition[], isGhost?: boolean}) => {
+const TransitionSet = ({ transitions, isGhost = false, isTemplate = false } : {transitions: PositionedTransition[], isGhost?: boolean, isTemplate?: boolean}) => {
   const projectType = useProjectStore(s => s.project.config.type)
   // Split the transitions into the two directions (left->right and right->left)
   // This makes the code easier since we don't need to handle direction changes
@@ -75,6 +75,7 @@ const TransitionSet = ({ transitions, isGhost = false } : {transitions: Position
         transitions={toRender}
         id={first.id}
         projectType={projectType}
+        isTemplate={isTemplate}
         {...props}
       />
     }
@@ -98,6 +99,7 @@ type TransitionProps = {
   fullWidth?: boolean,
   bendDirection?: BendDirection,
   suppressEvents?: boolean
+  isTemplate?: boolean
 }
 
 /**
@@ -134,7 +136,8 @@ const Transition = ({
   projectType,
   bendDirection = 'straight',
   fullWidth = false,
-  suppressEvents = false
+  suppressEvents = false,
+  isTemplate = false
 } : TransitionProps) => {
   const { standardArrowHead, selectedArrowHead } = useContext(MarkerContext)
 
@@ -237,7 +240,7 @@ const Transition = ({
     />}
 
     {/* Handles to drag the edge */}
-    {setSelected && <ChangeTransitionHandlebars
+    {!isTemplate && setSelected && <ChangeTransitionHandlebars
         edges={edges}
         selectedTransitions={selectedTransitions}
         isReflexive={isReflexive}

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -76,7 +76,9 @@ export interface CustomEvents {
   'modal:deleteConfirm': null,
   'modal:import': null,
   'showSharing': null,
-  'stackVisualiser:toggle': { state: boolean }
+  'stackVisualiser:toggle': { state: boolean },
+  'selectiongraph:show': null,
+  'selectiongraph:hide': null,
 }
 
 /**

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -77,8 +77,9 @@ export interface CustomEvents {
   'modal:import': null,
   'showSharing': null,
   'stackVisualiser:toggle': { state: boolean },
-  'selectiongraph:show': null,
-  'selectiongraph:hide': null,
+  'createTemplateThumbnail': string,
+  'storeTemplateThumbnail': string,
+  'selectionGraph:hide': null,
 }
 
 /**

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -74,6 +74,7 @@ export interface CustomEvents {
   'transitionhandle:mousedown': TransitionHandleEventData,
   'showWarning': string,
   'modal:deleteConfirm': null,
+  'modal:editorConfirmation': { title: string, description: string, tid: string },
   'modal:import': null,
   'showSharing': null,
   'stackVisualiser:toggle': { state: boolean },

--- a/frontend/src/hooks/useImageExport.ts
+++ b/frontend/src/hooks/useImageExport.ts
@@ -1,10 +1,11 @@
 import { useEffect } from 'react'
 
-import { useEvent } from '/src/hooks'
-import { useProjectStore, useExportStore, useThumbnailStore } from '/src/stores'
+import { dispatchCustomEvent } from '../util/events'
 import COLORS, { ColourName } from '/src/config/colors'
-import { Size } from '/src/types/ProjectTypes'
+import { useEvent } from '/src/hooks'
+import { useExportStore, useProjectStore, useThumbnailStore } from '/src/stores'
 import { Background } from '/src/stores/useExportStore'
+import { Size } from '/src/types/ProjectTypes'
 
 const SVG_NS = 'http://www.w3.org/2000/svg'
 
@@ -40,7 +41,7 @@ export const svgToCanvas = ({ height, width, svg }: Size & {svg: string}) => new
 })
 
 interface GetSvgStringProps {
-  svgElementTag?: string
+  svgElementTag?: 'automatarium-graph' | 'selected-graph'
   margin?: number
   background?: Background
   color?: ColourName | ''
@@ -160,13 +161,21 @@ const useImageExport = () => {
     }
   }, [project.meta.name])
 
-  // Generate thumbnail
+  // Generate project thumbnail
   useEffect(() => {
     window.setTimeout(() => {
       const { svg } = getSvgString()
       setThumbnail(project._id, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svg))
     }, 200)
   }, [project])
+
+  useEvent('storeTemplateThumbnail', e => {
+    window.setTimeout(() => {
+      const { svg } = getSvgString({ svgElementTag: 'selected-graph' })
+      setThumbnail(`tmp${e.detail}`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svg))
+      dispatchCustomEvent('selectionGraph:hide', null)
+    }, 200)
+  })
 }
 
 export default useImageExport

--- a/frontend/src/hooks/useImageExport.ts
+++ b/frontend/src/hooks/useImageExport.ts
@@ -40,6 +40,7 @@ export const svgToCanvas = ({ height, width, svg }: Size & {svg: string}) => new
 })
 
 interface GetSvgStringProps {
+  svgElementTag?: string
   margin?: number
   background?: Background
   color?: ColourName | ''
@@ -48,17 +49,18 @@ interface GetSvgStringProps {
 
 // Extract the SVG graph as a string
 export const getSvgString = ({
+  svgElementTag = 'automatarium-graph',
   margin = 20,
   background = 'none',
   color = null,
   darkMode = false
 }: GetSvgStringProps = {}) => {
   // Clone the SVG element
-  const svgElement = document.querySelector('#automatarium-graph') as SVGGraphicsElement
+  const svgElement = document.querySelector(`#${svgElementTag}`) as SVGGraphicsElement
   const clonedSvgElement = svgElement.cloneNode(true) as SVGGraphicsElement
 
   // Set viewbox
-  const b = (document.querySelector('#automatarium-graph > g') as SVGGraphicsElement).getBBox()
+  const b = (svgElement.querySelector('g') as SVGGraphicsElement).getBBox()
   margin = Number(margin ?? 0) + 1
   const [x, y, width, height] = [b.x - margin, b.y - margin, b.width + margin * 2, b.height + margin * 2]
   clonedSvgElement.setAttribute('viewBox', `${x} ${y} ${width} ${height}`)

--- a/frontend/src/hooks/useTemplateInsert.ts
+++ b/frontend/src/hooks/useTemplateInsert.ts
@@ -33,7 +33,6 @@ const useTemplateInsert = () => {
       const copyTemplate = structuredClone(template)
       moveStatesToMouse(positionFromEvent(e), copyTemplate.states, copyTemplate.comments)
       const insertResponse = insertGroup(copyTemplate, true)
-      console.log(insertResponse)
       if (insertResponse.type === InsertGroupResponseType.SUCCESS) {
         selectComments(insertResponse.body.comments.map(comment => comment.id))
         selectStates(insertResponse.body.states.map(state => state.id))

--- a/frontend/src/hooks/useTemplateInsert.ts
+++ b/frontend/src/hooks/useTemplateInsert.ts
@@ -1,6 +1,6 @@
 import { useEvent } from '/src/hooks'
 import { useProjectStore, useSelectionStore, useTemplateStore } from '/src/stores'
-import { AutomataState } from '/src/types/ProjectTypes'
+import { AutomataState, ProjectComment, Template } from '/src/types/ProjectTypes'
 import { InsertGroupResponseType } from '../stores/useProjectStore'
 import { snapPosition } from '/src/util/points'
 import { useState } from 'react'
@@ -31,7 +31,7 @@ const useTemplateInsert = () => {
     setShowGhost(false)
     if (template !== null && e.detail.didTargetSVG && e.detail.originalEvent.button === 0) {
       const copyTemplate = structuredClone(template)
-      moveStatesToMouse(positionFromEvent(e), copyTemplate.states)
+      moveStatesToMouse(positionFromEvent(e), copyTemplate.states, copyTemplate.comments)
       const insertResponse = insertGroup(copyTemplate, true)
       console.log(insertResponse)
       if (insertResponse.type === InsertGroupResponseType.SUCCESS) {
@@ -54,7 +54,7 @@ const positionFromEvent = (e: CustomEvent) => {
   return doSnap ? snapPosition(pos) : pos
 }
 
-export const moveStatesToMouse = (mousePos: {x: number, y: number}, states: AutomataState[]) => {
+export const moveStatesToMouse = (mousePos: {x: number, y: number}, states: AutomataState[], comments: ProjectComment[]) => {
   // Find the leftmost state (lowest x val)
   const originState = states.reduce((previous, current) => {
     return current.x < previous.x ? current : previous
@@ -65,6 +65,12 @@ export const moveStatesToMouse = (mousePos: {x: number, y: number}, states: Auto
     state.x += offsetX
     state.y += offsetY
   })
+  if (comments) {
+    comments.forEach(comment => {
+      comment.x += offsetX
+      comment.y += offsetY
+    })
+  }
 }
 
 export default useTemplateInsert

--- a/frontend/src/pages/Editor/Editor.tsx
+++ b/frontend/src/pages/Editor/Editor.tsx
@@ -1,21 +1,23 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { useActions, useEvent } from '/src/hooks'
-import { useToolStore, useProjectStore, useExportStore, useViewStore } from '/src/stores'
-import { haveInputFocused } from '/src/util/actions'
-import { Menubar, Sidepanel, Toolbar, EditorPanel, BottomPanel } from '/src/components'
-import { ShortcutGuide, ExportImage, ShareUrl, ImportDialog } from '/src/pages'
 import { Content, EditorContent } from './editorStyle'
+import { BottomPanel, EditorPanel, Menubar, Sidepanel, Toolbar } from '/src/components'
+import { useActions, useEvent } from '/src/hooks'
+import { ExportImage, ImportDialog, ShareUrl, ShortcutGuide } from '/src/pages'
+import { useExportStore, useProjectStore, useToolStore, useViewStore } from '/src/stores'
+import { haveInputFocused } from '/src/util/actions'
 
 import PDAStackVisualiser from '../../components/PDAStackVisualiser/stackVisualiser'
 import { useAutosaveProject } from '../../hooks'
+import TemplateDelConfDialog from './components/TempleteDelConfDialog/TemplateDelConfDialog'
 import { Tool } from '/src/stores/useToolStore'
 
 const Editor = () => {
   const navigate = useNavigate()
   const { tool, setTool } = useToolStore()
   const [priorTool, setPriorTool] = useState<Tool>()
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false)
   const resetExportSettings = useExportStore(s => s.reset)
   const setViewPositionAndScale = useViewStore(s => s.setViewPositionAndScale)
   const project = useProjectStore(s => s.project)
@@ -102,6 +104,12 @@ const Editor = () => {
       <ExportImage />
 
       <ShareUrl />
+
+      <TemplateDelConfDialog
+        isOpen={confirmDialogOpen}
+        setOpen={() => setConfirmDialogOpen(true)}
+        setClose={() => setConfirmDialogOpen(false)}
+      />
 
       <ImportDialog navigateFunction={navigate} />
 

--- a/frontend/src/pages/Editor/components/TempleteDelConfDialog/TemplateDelConfDialog.tsx
+++ b/frontend/src/pages/Editor/components/TempleteDelConfDialog/TemplateDelConfDialog.tsx
@@ -1,0 +1,43 @@
+import { useState } from 'react'
+import { Button, Modal } from '/src/components'
+import { useEvent } from '/src/hooks'
+import { useTemplatesStore } from '/src/stores'
+
+type EditorConfirmationProps = {
+  isOpen: boolean
+  setOpen: () => void
+  setClose: () => void
+}
+
+const TemplateDelConfDialog = ({ isOpen, setOpen, setClose }: EditorConfirmationProps) => {
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [tid, setTid] = useState<string>()
+  const deleteTemplate = useTemplatesStore(s => s.deleteTemplate)
+
+  useEvent('modal:editorConfirmation', ({ detail: { title, description, tid } }) => {
+    setTitle(title)
+    setDescription(description)
+    setTid(tid)
+    window.setTimeout(() => setOpen(), 50)
+  }, [])
+
+  return (
+    <Modal
+        title={title}
+        description={description}
+        isOpen={isOpen}
+        onClose={setClose}
+        role='alertdialog'
+        actions={<>
+          <Button secondary onClick={setClose}>Cancel</Button>
+          <Button onClick={() => {
+            deleteTemplate(tid)
+            setClose()
+          }}>Confirm</Button>
+        </>}
+    />
+  )
+}
+
+export default TemplateDelConfDialog

--- a/frontend/src/pages/Editor/components/TempleteDelConfDialog/TemplateDelConfDialog.tsx
+++ b/frontend/src/pages/Editor/components/TempleteDelConfDialog/TemplateDelConfDialog.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Button, Modal } from '/src/components'
 import { useEvent } from '/src/hooks'
-import { useTemplatesStore } from '/src/stores'
+import { useTemplatesStore, useThumbnailStore } from '/src/stores'
 
 type EditorConfirmationProps = {
   isOpen: boolean
@@ -14,6 +14,7 @@ const TemplateDelConfDialog = ({ isOpen, setOpen, setClose }: EditorConfirmation
   const [description, setDescription] = useState('')
   const [tid, setTid] = useState<string>()
   const deleteTemplate = useTemplatesStore(s => s.deleteTemplate)
+  const removeThumbnail = useThumbnailStore(s => s.removeThumbnail)
 
   useEvent('modal:editorConfirmation', ({ detail: { title, description, tid } }) => {
     setTitle(title)
@@ -33,6 +34,7 @@ const TemplateDelConfDialog = ({ isOpen, setOpen, setClose }: EditorConfirmation
           <Button secondary onClick={setClose}>Cancel</Button>
           <Button onClick={() => {
             deleteTemplate(tid)
+            removeThumbnail(`tmp${tid}`)
             setClose()
           }}>Confirm</Button>
         </>}

--- a/frontend/src/pages/NewFile/NewFile.tsx
+++ b/frontend/src/pages/NewFile/NewFile.tsx
@@ -53,7 +53,7 @@ const NewFile = () => {
   // Remove old thumbnails
   useEffect(() => {
     if (projects.length) {
-      Object.keys(thumbnails).forEach(id => !projects.some(p => p._id === id) && removeThumbnail(id))
+      Object.keys(thumbnails).forEach(id => !id.startsWith('tmp') && !projects.some(p => p._id === id) && removeThumbnail(id))
     }
   }, [projects, thumbnails])
 


### PR DESCRIPTION
Closes #415. Renders the selected elements when adding a template into the thumbnail store.

Currently it is creating a copy of the elements that are selected into a new SVG element, but it will flash on the screen for a brief moment. Not sure how to fix that without messing up the containers.

Other things that were changed:
- Template thumbnails use the same store as project thumbnails with a `tmp` added at the start
- Modified the project card (which the templates use) to have a bin icon for deleting a template. This action should also delete delete the thumbnail from store (otherwise a garbage cleanup-esque routine like done with the project thumbnails causes a stack overflow)
- The template ghost appears while a template is selected and follows the mouse

Other things to be fixed:
- The template svg element flashing on the screen
- Comments not being rendered as `useImageExport` does not include comments
