### PR TITLE
Thumbnails conform with app theme

### DIFF
--- a/frontend/src/components/ProjectCard/projectCardStyle.ts
+++ b/frontend/src/components/ProjectCard/projectCardStyle.ts
@@ -30,7 +30,7 @@ export const CardImage = styled('div')<{$image?: boolean}>`
   align-items: center;
   justify-content: center;
   position: relative;
-  background: var(--grid-bg-light);
+  background: var(--grid-bg);
 
   svg {
     width: 60%;
@@ -46,7 +46,7 @@ export const CardImage = styled('div')<{$image?: boolean}>`
   }
 
   ${props => !props.$image && `
-    background: var(--grid-pattern-light);
+    background: var(--grid-pattern);
     background-size: 1.875em 1.875em;
     background-position: .4735em .4735em;
   `}

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -1,4 +1,4 @@
-import { useTemplatesStore, useTemplateStore, useSelectionStore, useProjectStore, useToolStore, useThumbnailStore } from '/src/stores'
+import { useTemplatesStore, useTemplateStore, useSelectionStore, useProjectStore, useToolStore, useThumbnailStore, usePreferencesStore } from '/src/stores'
 import { SectionLabel, Input, Button, ProjectCard } from '/src/components'
 import { CardList } from '/src/pages/NewFile/components'
 import { selectionToCopyTemplate } from '/src/hooks/useActions'
@@ -31,6 +31,14 @@ const Templates = () => {
   const setTool = useToolStore(s => s.setTool)
 
   const thumbs = useThumbnailStore(s => s.thumbnails)
+  const theme = usePreferencesStore(s => s.preferences).theme
+
+  const getThumbTheme = useCallback((id: string) => {
+    const thumbTheme = theme === 'system'
+      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? 'dark' : 'light'
+      : theme
+    return `tmp${id}-${thumbTheme}`
+  }, [theme])
 
   const [templateNameInput, setTemplateNameInput] = useState('')
   const [error, setError] = useState('')
@@ -113,7 +121,7 @@ const Templates = () => {
                 name={temp.name}
                 date={dayjs(temp.date)}
                 width={TEMPLATE_THUMBNAIL_WIDTH}
-                image={thumbs[`tmp${temp._id}`]}
+                image={thumbs[getThumbTheme(temp._id)]}
                 $istemplate={true}
                 $deleteTemplate={e => {
                   e.stopPropagation()

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -35,9 +35,9 @@ const Templates = () => {
 
   const getThumbTheme = useCallback((id: string) => {
     const thumbTheme = theme === 'system'
-      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? 'dark' : 'light'
-      : theme
-    return `tmp${id}-${thumbTheme}`
+      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? '-dark' : ''
+      : theme === 'dark' ? '-dark' : ''
+    return `tmp${id}${thumbTheme}`
   }, [theme])
 
   const [templateNameInput, setTemplateNameInput] = useState('')

--- a/frontend/src/hooks/useImageExport.ts
+++ b/frontend/src/hooks/useImageExport.ts
@@ -166,7 +166,7 @@ const useImageExport = () => {
     window.setTimeout(() => {
       const { svg: svgLight } = getSvgString({ darkMode: false })
       const { svg: svgDark } = getSvgString({ darkMode: true })
-      setThumbnail(`${project._id}-light`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
+      setThumbnail(project._id, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
       setThumbnail(`${project._id}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
     }, 200)
   }, [project])
@@ -175,7 +175,7 @@ const useImageExport = () => {
     window.setTimeout(() => {
       const { svg: svgLight } = getSvgString({ svgElementTag: 'selected-graph', darkMode: false })
       const { svg: svgDark } = getSvgString({ svgElementTag: 'selected-graph', darkMode: true })
-      setThumbnail(`tmp${e.detail}-light`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
+      setThumbnail(`tmp${e.detail}`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
       setThumbnail(`tmp${e.detail}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
       dispatchCustomEvent('selectionGraph:hide', null)
     }, 200)

--- a/frontend/src/hooks/useImageExport.ts
+++ b/frontend/src/hooks/useImageExport.ts
@@ -164,15 +164,19 @@ const useImageExport = () => {
   // Generate project thumbnail
   useEffect(() => {
     window.setTimeout(() => {
-      const { svg } = getSvgString()
-      setThumbnail(project._id, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svg))
+      const { svg: svgLight } = getSvgString({ darkMode: false })
+      const { svg: svgDark } = getSvgString({ darkMode: true })
+      setThumbnail(`${project._id}-light`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
+      setThumbnail(`${project._id}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
     }, 200)
   }, [project])
 
   useEvent('storeTemplateThumbnail', e => {
     window.setTimeout(() => {
-      const { svg } = getSvgString({ svgElementTag: 'selected-graph' })
-      setThumbnail(`tmp${e.detail}`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svg))
+      const { svg: svgLight } = getSvgString({ svgElementTag: 'selected-graph', darkMode: false })
+      const { svg: svgDark } = getSvgString({ svgElementTag: 'selected-graph', darkMode: true })
+      setThumbnail(`tmp${e.detail}-light`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
+      setThumbnail(`tmp${e.detail}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
       dispatchCustomEvent('selectionGraph:hide', null)
     }, 200)
   })

--- a/frontend/src/pages/Editor/components/TempleteDelConfDialog/TemplateDelConfDialog.tsx
+++ b/frontend/src/pages/Editor/components/TempleteDelConfDialog/TemplateDelConfDialog.tsx
@@ -34,7 +34,8 @@ const TemplateDelConfDialog = ({ isOpen, setOpen, setClose }: EditorConfirmation
           <Button secondary onClick={setClose}>Cancel</Button>
           <Button onClick={() => {
             deleteTemplate(tid)
-            removeThumbnail(`tmp${tid}`)
+            removeThumbnail(`tmp${tid}-light`)
+            removeThumbnail(`tmp${tid}-dark`)
             setClose()
           }}>Confirm</Button>
         </>}

--- a/frontend/src/pages/NewFile/NewFile.tsx
+++ b/frontend/src/pages/NewFile/NewFile.tsx
@@ -47,9 +47,9 @@ const NewFile = () => {
   const theme = preferences.theme === 'system' ? '' : `-${preferences.theme}`
   const getThumbTheme = useCallback((id: string) => {
     const thumbTheme = preferences.theme === 'system'
-      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? 'dark' : 'light'
-      : preferences.theme
-    return `${id}-${thumbTheme}`
+      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? '-dark' : ''
+      : preferences.theme === 'dark' ? '-dark' : ''
+    return `${id}${thumbTheme}`
   }, [preferences.theme])
   const stylingVals = {
     stateFill: `var(--state-bg${theme})`,
@@ -59,7 +59,7 @@ const NewFile = () => {
   // Remove old thumbnails
   useEffect(() => {
     if (projects.length) {
-      Object.keys(thumbnails).forEach(id => !id.startsWith('tmp') && !projects.some(p => `${p._id}-light` === id || `${p._id}-dark` === id) && removeThumbnail(id))
+      Object.keys(thumbnails).forEach(id => !id.startsWith('tmp') && !projects.some(p => p._id === id || `${p._id}-dark` === id) && removeThumbnail(id))
     }
   }, [projects, thumbnails])
 

--- a/frontend/src/pages/NewFile/NewFile.tsx
+++ b/frontend/src/pages/NewFile/NewFile.tsx
@@ -45,6 +45,12 @@ const NewFile = () => {
   // Will likely be extended to 'Your Projects' list
   // If matching system theme, don't append a theme to css vars
   const theme = preferences.theme === 'system' ? '' : `-${preferences.theme}`
+  const getThumbTheme = useCallback((id: string) => {
+    const thumbTheme = preferences.theme === 'system'
+      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? 'dark' : 'light'
+      : preferences.theme
+    return `${id}-${thumbTheme}`
+  }, [preferences.theme])
   const stylingVals = {
     stateFill: `var(--state-bg${theme})`,
     strokeColor: `var(--stroke${theme})`
@@ -128,7 +134,7 @@ const NewFile = () => {
           name={p?.meta?.name ?? '<Untitled>'}
           type={p?.config?.type ?? '???'}
           date={dayjs(p?.meta?.dateEdited)}
-          image={thumbnails[p._id]}
+          image={thumbnails[getThumbTheme(p._id)]}
           width={PROJECT_THUMBNAIL_WIDTH}
           onClick={() => handleLoadProject(p)}
           $kebabClick={(event) => {

--- a/frontend/src/pages/NewFile/NewFile.tsx
+++ b/frontend/src/pages/NewFile/NewFile.tsx
@@ -53,7 +53,7 @@ const NewFile = () => {
   // Remove old thumbnails
   useEffect(() => {
     if (projects.length) {
-      Object.keys(thumbnails).forEach(id => !id.startsWith('tmp') && !projects.some(p => p._id === id) && removeThumbnail(id))
+      Object.keys(thumbnails).forEach(id => !id.startsWith('tmp') && !projects.some(p => `${p._id}-light` === id || `${p._id}-dark` === id) && removeThumbnail(id))
     }
   }, [projects, thumbnails])
 


### PR DESCRIPTION
Closes #298. While I'm already working on thumbnails might as well push this through too.

- Thumbnails generate both light and dark modes in store so they can be swapped at will
- Thumbnails switch between a `-dark` and no (light) suffix and are generated on save, so thumbnails for old projects in dark mode will be broken (just make a change in a project to get a new one)
- This also applied to templates

#### Light
![image](https://github.com/automatarium/automatarium/assets/82514325/f961c22e-0f58-4b8e-982b-eb6cc23c0a10)
#### Dark
![image](https://github.com/automatarium/automatarium/assets/82514325/26b791f4-104e-44b1-add8-85e119b07e12)

Ignore the broken ones, they got erased when I specified light with `-light`.