### PR TITLE
Exclusion inputs in transitions

### DIFF
--- a/frontend/src/components/InputDialogs/InputDialogs.tsx
+++ b/frontend/src/components/InputDialogs/InputDialogs.tsx
@@ -6,7 +6,7 @@ import { useProjectStore, useViewStore } from '/src/stores'
 import useEvent from '/src/hooks/useEvent'
 import { locateTransition } from '/src/util/states'
 import { lerpPoints } from '/src/util/points'
-import { formatInput, splitCharsWithOr } from '/src/util/stringManipulations'
+import { formatInput, formatOutput } from '/src/util/stringManipulations'
 import { DirectionRadioButtons } from '/src/components/Button/DirectionRadioButtons'
 
 import {
@@ -108,7 +108,7 @@ const InputDialogs = () => {
     switch (projectType) {
       case 'TM':
         assertType<TMAutomataTransition>(transition)
-        setValue(splitCharsWithOr(transition?.read, orOperator) ?? '')
+        setValue(formatOutput(transition?.read, orOperator) ?? '')
         setWrite(transition?.write ?? '')
         setDirection(transition?.direction ?? 'R')
         setDialog({
@@ -121,7 +121,7 @@ const InputDialogs = () => {
         break
       case 'PDA':
         assertType<PDAAutomataTransition>(transition)
-        setValue(splitCharsWithOr(transition?.read, orOperator) ?? '')
+        setValue(formatOutput(transition?.read, orOperator) ?? '')
         setValuePush(transition?.push ?? '')
         setValuePop(transition?.pop ?? '')
         setDialog({
@@ -133,7 +133,7 @@ const InputDialogs = () => {
         })
         break
       case 'FSA':
-        setValue(splitCharsWithOr(transition?.read, orOperator) ?? '')
+        setValue(formatOutput(transition?.read, orOperator) ?? '')
         setDialog({
           visible: true,
           x: screenMidPoint[0],

--- a/frontend/src/components/InputDialogs/InputDialogs.tsx
+++ b/frontend/src/components/InputDialogs/InputDialogs.tsx
@@ -6,7 +6,7 @@ import { useProjectStore, useViewStore } from '/src/stores'
 import useEvent from '/src/hooks/useEvent'
 import { locateTransition } from '/src/util/states'
 import { lerpPoints } from '/src/util/points'
-import { formatInput, splitCharsWithOr } from '/src/util/orOperators'
+import { formatInput, splitCharsWithOr } from '/src/util/stringManipulations'
 import { DirectionRadioButtons } from '/src/components/Button/DirectionRadioButtons'
 
 import {

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -33,7 +33,7 @@ import {
   TMDirection,
   assertType
 } from '/src/types/ProjectTypes'
-import { splitCharsWithOr, formatInput } from '/src/util/orOperators'
+import { splitCharsWithOr, formatInput } from '/src/util/stringManipulations'
 
 const InputTransitionGroup = () => {
   const inputRef = useRef<HTMLInputElement>()

--- a/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
+++ b/frontend/src/components/InputTransitionGroup/InputTransitionGroup.tsx
@@ -33,7 +33,7 @@ import {
   TMDirection,
   assertType
 } from '/src/types/ProjectTypes'
-import { splitCharsWithOr, formatInput } from '/src/util/stringManipulations'
+import { formatOutput, formatInput } from '/src/util/stringManipulations'
 
 const InputTransitionGroup = () => {
   const inputRef = useRef<HTMLInputElement>()
@@ -385,7 +385,7 @@ const InputTransitionGroup = () => {
                 <InputWrapper key={i}>
                   <Input
                     ref={transitionListRef[i] ?? null}
-                    value={splitCharsWithOr(t.read, orOperator)}
+                    value={formatOutput(t.read, orOperator)}
                     onChange={(e) => {
                       saveFSATransition({
                         id: t.id,
@@ -419,7 +419,7 @@ const InputTransitionGroup = () => {
                   <InputSpacingWrapper>
                     <Input
                       ref={transitionListRef[i] ?? null}
-                      value={splitCharsWithOr(t.read, orOperator)}
+                      value={formatOutput(t.read, orOperator)}
                       onChange={(e) => {
                         savePDATransition({
                           id: t.id,
@@ -494,7 +494,7 @@ const InputTransitionGroup = () => {
                   <InputSpacingWrapper>
                     <Input
                       ref={transitionListRef[i] ?? null}
-                      value={splitCharsWithOr(t.read, orOperator)}
+                      value={formatOutput(t.read, orOperator)}
                       onChange={(e) => {
                         saveTMTransition({
                           id: t.id,

--- a/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
@@ -56,6 +56,7 @@ const Info = () => {
     }
     return map
   }, [states, alphabet, graph])
+
   return <>
     <SectionLabel>Alphabet</SectionLabel>
     <Wrapper>

--- a/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
@@ -6,6 +6,7 @@ import { Table, SectionLabel } from '/src/components'
 
 import { Wrapper, Symbol, SymbolList } from './infoStyle'
 import { StateID } from '@automatarium/simulation/src/graph'
+import { TMAutomataTransition } from '/src/types/ProjectTypes'
 
 const Info = () => {
   const statePrefix = useProjectStore(s => s.project?.config?.statePrefix)
@@ -23,13 +24,14 @@ const Info = () => {
   const alphabet = useMemo(() => {
     return Array.from(
       new Set(
-        graph.transitions
-          .reduce((acc, tr) => {
-            return tr.read.startsWith('!')
-              ? [...acc, tr.read]
-              : [...acc, ...tr.read.split('')]
-          }, [] as string[])
-          .sort()
+      (graph.transitions as TMAutomataTransition[])
+        .reduce((acc, tr) => {
+          // Type assertion here
+          return tr.read.startsWith('!')
+            ? [...acc, tr.read]
+            : [...acc, ...tr.read.split('')]
+        }, [] as string[])
+        .sort() as string[]
       )
     )
   }, [transitions])

--- a/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
@@ -20,13 +20,19 @@ const Info = () => {
   )
 
   // Determine alphabet
-  const alphabet = useMemo(() =>
-    Array.from(new Set(graph.transitions
-      .map(tr => tr.read)
-      .reduce((a, b) => [...a, ...b], [] as string[])
-      .sort() as string[]
-    ))
-  , [transitions])
+  const alphabet = useMemo(() => {
+    return Array.from(
+      new Set(
+        graph.transitions
+          .reduce((acc, tr) => {
+            return tr.read.startsWith('!')
+              ? [...acc, tr.read]
+              : [...acc, ...tr.read.split('')]
+          }, [] as string[])
+          .sort()
+      )
+    )
+  }, [transitions])
 
   const transitionMap = useMemo(() => {
     const map = new Map<[StateID, string], StateID[]>() // (ID, Symbol) -> ID[]

--- a/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Info/Info.tsx
@@ -6,7 +6,7 @@ import { Table, SectionLabel } from '/src/components'
 
 import { Wrapper, Symbol, SymbolList } from './infoStyle'
 import { StateID } from '@automatarium/simulation/src/graph'
-import { TMAutomataTransition, PDAProjectGraph } from "/src/types/ProjectTypes"
+import { TMAutomataTransition, PDAProjectGraph } from '/src/types/ProjectTypes'
 
 const Info = () => {
   const statePrefix = useProjectStore(s => s.project?.config?.statePrefix)

--- a/frontend/src/components/Sidepanel/Panels/Info/infoStyle.ts
+++ b/frontend/src/components/Sidepanel/Panels/Info/infoStyle.ts
@@ -10,12 +10,14 @@ export const Wrapper = styled('div')`
 `
 
 export const Symbol = styled('div')`
-  display: flex;
+  display: inline-block;
   align-items: center;
   text-align: center;
   justify-content: center;
-  width: 2em;
-  aspect-ratio: 1 / 1;
+  min-width: 2em;
+  height: 2em;
+  line-height: 2em;
+  padding: 0 0.5em;
   background: var(--toolbar);
   border-radius: .2rem;
   box-sizing: border-box;

--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
@@ -75,7 +75,7 @@ const TestingLab = () => {
               : simulateFSA(graph, input ?? '')
       // Formats a symbol. Makes an empty symbol become a lambda
       const formatSymbol = (char?: string): string =>
-        char === null || char === "" ? "λ" : char;
+        char === null || char === '' ? 'λ' : char
       return {
         ...result,
         // We need format the symbols in the trace so any empty symbols become lambdas

--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
@@ -74,7 +74,8 @@ const TestingLab = () => {
               ? simulatePDA(graph, input ?? '')
               : simulateFSA(graph, input ?? '')
       // Formats a symbol. Makes an empty symbol become a lambda
-      const formatSymbol = (char?: string): string => char === '' ? 'λ' : char
+      const formatSymbol = (char?: string): string =>
+        char === null || char === "" ? "λ" : char;
       return {
         ...result,
         // We need format the symbols in the trace so any empty symbols become lambdas

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -9,7 +9,7 @@ import { dispatchCustomEvent } from '/src/util/events'
 import { lerpPoints, movePointTowards, size } from '/src/util/points'
 import { PositionedTransition } from '/src/util/states'
 import { assertType, Coordinate, PDAAutomataTransition, ProjectType, TMAutomataTransition } from '/src/types/ProjectTypes'
-import { splitCharsWithOr } from '/src/util/orOperators'
+import { splitCharsWithOr } from '/src/util/stringManipulations'
 
 /**
  * Creates the transition text depending on the project type. Uses the following notation

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -9,7 +9,7 @@ import { dispatchCustomEvent } from '/src/util/events'
 import { lerpPoints, movePointTowards, size } from '/src/util/points'
 import { PositionedTransition } from '/src/util/states'
 import { assertType, Coordinate, PDAAutomataTransition, ProjectType, TMAutomataTransition } from '/src/types/ProjectTypes'
-import { splitCharsWithOr } from '/src/util/stringManipulations'
+import { formatOutput } from '/src/util/stringManipulations'
 
 /**
  * Creates the transition text depending on the project type. Uses the following notation
@@ -22,12 +22,12 @@ const makeTransitionText = (type: ProjectType, orOperator: string, t: Positioned
   switch (type) {
     case 'TM':
       assertType<TMAutomataTransition>(t)
-      return `${splitCharsWithOr(t.read, orOperator) || 'λ'} , ${t.write || 'λ'} ; ${t.direction || 'λ'}`
+      return `${formatOutput(t.read, orOperator) || 'λ'} , ${t.write || 'λ'} ; ${t.direction || 'λ'}`
     case 'PDA':
       assertType<PDAAutomataTransition>(t)
-      return `${splitCharsWithOr(t.read, orOperator) || 'λ'} , ${t.pop || 'λ'} ; ${t.push || 'λ'}`
+      return `${formatOutput(t.read, orOperator) || 'λ'} , ${t.pop || 'λ'} ; ${t.push || 'λ'}`
     case 'FSA':
-      return splitCharsWithOr(t.read, orOperator) || 'λ'
+      return formatOutput(t.read, orOperator) || 'λ'
   }
 }
 

--- a/frontend/src/util/stringManipulations.ts
+++ b/frontend/src/util/stringManipulations.ts
@@ -1,5 +1,3 @@
-import { expandReadSymbols } from '@automatarium/simulation'
-
 export const possibleOrOperators = (orOperator: string): string[] => {
   switch (orOperator) {
     case '+':
@@ -44,15 +42,14 @@ export const splitCharsWithOr = (text: string, orOperator: string): string => {
 
 // Gets symbols that are preceded by an exclusion operator (!)
 export const extractSymbolsToExclude = (input: string): string[] => {
-  const matches = input.match(/(!\.)|(!\(([^&)]+&)*[^&)]*\))|(!\[[^\]]*\])|(![^()[\]]+)|!\(|!\[/g) || []
+  const matches = input.match(/(!\.)|(!\(([^&)]+&)*[^&)]*\))|(![^()[\]]+)|!\(|!\[/g) || []
 
   return matches.flatMap((match: string) => {
     if (match.startsWith('!(')) {
       if (match === '!(') return ['(']
       return match.slice(2, -1).split('&').flatMap(s => s.length > 1 ? s.split('') : s)
-    } else if (match.startsWith('![')) {
-      if (match === '![') return ['[']
-      return expandReadSymbols(match.slice(2, -1)).split('')
+    } else if (match === '![') {
+      return ['[']
     } else if (match.startsWith('!')) {
       return match.slice(1).split('')
     }

--- a/frontend/src/util/stringManipulations.ts
+++ b/frontend/src/util/stringManipulations.ts
@@ -41,41 +41,45 @@ export const splitCharsWithOr = (text: string, orOperator: string): string => {
   return parts.join(joinStr);
 }
 
-/**
- * Removes OR operators and rearranges the read string when a range is present
- * All single characters come before ranges
- * e.g. [a-b]ad[l-k] becomes ad[a-b][l-k]
- */
-export const formatInput = (input: string, orOperator: string): string => {
-  // Remove whitespace
-  input = input.replace(/\s+/g, '');
+export const removeWhitespace = (input: string): string => {
+  return input.replace(/\s+/g, '');
+}
 
-  // Remove or operators
+export const removeOrOperators = (input: string, orOperator: string): string => {
   for (const op of possibleOrOperators(orOperator)) {
     input = input.split(op).join('');
   }
+  return input;
+}
 
-  // Extract ranges
+export const removeDuplicateChars = (input: string): string => {
+  return Array.from(new Set(input.split(''))).join('');
+}
+
+export const extractRanges = (input: string): [string, string[]] => {
   const ranges = input.match(/\[(.*?)]/g) || [];
   input = input.replace(/\[(.*?)]/g, '');
+  return [input, ranges];
+}
 
-  // Extract all valid exclusions
+// Exclusions are denoted with ! followed by the character to exclude
+export const extractAndRemoveExclusions = (input: string): [string, string] => {
   const exclusionMatches = input.match(/!+([^!])/g) || [];
-
-  // Remove those valid exclusions from the input
   for (const match of exclusionMatches) {
     input = input.replace(match, '');
   }
-
-  // Remove all standalone `!` symbols
   input = input.replace(/!+/g, '');
-
-  // Construct the unique exclusions
   const uniqueExclusions = Array.from(new Set(exclusionMatches.map(match => '!' + match[match.length - 1]))).join('');
-
-  // Add back ranges
-  return `${input}${uniqueExclusions}${ranges.join('')}`;
+  return [input, uniqueExclusions];
 }
 
 
-
+// If the input is 'a[w-z]a!!b', the output will be 'a!b[w-z]'
+export const formatInput = (input: string, orOperator: string): string => {
+  input = removeWhitespace(input);
+  input = removeOrOperators(input, orOperator);
+  input = removeDuplicateChars(input)
+  const [inputWithoutRanges, ranges] = extractRanges(input);
+  const [finalInput, uniqueExclusions] = extractAndRemoveExclusions(inputWithoutRanges);
+  return `${finalInput}${uniqueExclusions}${ranges.join('')}`;
+}

--- a/frontend/src/util/stringManipulations.ts
+++ b/frontend/src/util/stringManipulations.ts
@@ -118,7 +118,6 @@ export const formatInput = (input: string, orOperator: string): string => {
   input = removeWhitespace(inputWithoutRanges)
   input = removeOrOperators(input, orOperator)
   input = removeDuplicateChars(input)
-  console.log(`${input}${ranges.join('')}`)
 
   return `${input}${ranges.join('')}`
 }

--- a/frontend/src/util/stringManipulations.ts
+++ b/frontend/src/util/stringManipulations.ts
@@ -34,12 +34,9 @@ export const splitCharsWithOr = (text: string, orOperator: string): string => {
   if (!text || text.length <= 1) return text
 
   const joinStr = orOperator !== ' ' ? ` ${orOperator} ` : ' '
+  const parts = text.match(/(\[.*?])|(![^ ]+)|([^! ])/g) || []
 
-  const parts = text.match(/(\[.*?])|(![^!]*)|(.)+/g) || []
-
-  return parts.map(part =>
-    (part.length === 1 && part !== '!') || part.startsWith('!') ? part : part.split('').join(joinStr)
-  ).join(joinStr)
+  return parts.join(joinStr)
 }
 
 // Gets symbols that are preceded by an exclusion operator (!)

--- a/frontend/src/util/stringManipulations.ts
+++ b/frontend/src/util/stringManipulations.ts
@@ -1,3 +1,5 @@
+import { expandReadSymbols } from '@automatarium/simulation/src/parseGraph'
+
 export const possibleOrOperators = (orOperator: string): string[] => {
   switch (orOperator) {
     case '+':
@@ -42,12 +44,14 @@ export const splitCharsWithOr = (text: string, orOperator: string): string => {
 
 // Gets symbols that are preceded by an exclusion operator (!)
 export const extractSymbolsToExclude = (input: string): string[] => {
-  const matches = input.match(/(!\.)|(!\(([^&)]+&)*[^&)]*\))|(![^()[\]]+)|!\(|!\[/g) || []
+  const matches = input.match(/(!\.)|(!\(([^&)]+&)*[^&)]*\))|(!\[[^\]]+\])|(![^()[\]]+)|!\(|!\[/g) || []
 
   return matches.flatMap((match: string) => {
     if (match.startsWith('!(')) {
       if (match === '!(') return ['(']
       return match.slice(2, -1).split('&').flatMap(s => s.length > 1 ? s.split('') : s)
+    } else if (match.startsWith('![')) {
+      return expandReadSymbols(match.slice(1)).split('')
     } else if (match === '![') {
       return ['[']
     } else if (match.startsWith('!')) {
@@ -117,6 +121,7 @@ export const formatInput = (input: string, orOperator: string): string => {
   input = removeWhitespace(inputWithoutRanges)
   input = removeOrOperators(input, orOperator)
   input = removeDuplicateChars(input)
+  console.log(`${input}${ranges.join('')}`)
 
   return `${input}${ranges.join('')}`
 }

--- a/frontend/src/util/stringManipulations.ts
+++ b/frontend/src/util/stringManipulations.ts
@@ -33,53 +33,51 @@ export const splitCharsWithOr = (text: string, orOperator: string): string => {
   let joinStr = ' '
   if (orOperator !== ' ') { joinStr = ` ${orOperator} ` }
 
-  // Don't insert OR symbols inside ranges or between NOT operator (!) and following character 
-  const regex = /(\[.*?])|(!+[a-zA-Z])|([a-zA-Z])/g
-  let matches = Array.from(text.matchAll(regex))
-  let parts = matches.map(match => match[0])
-
-  return parts.join(joinStr);
+  const parts = text.match(/(\[.*?])|(![^!])|([^!])/g)
+  return parts ? parts.join(joinStr) : ''
 }
 
 export const removeWhitespace = (input: string): string => {
-  return input.replace(/\s+/g, '');
+  return input.replace(/\s+/g, '')
 }
 
 export const removeOrOperators = (input: string, orOperator: string): string => {
   for (const op of possibleOrOperators(orOperator)) {
-    input = input.split(op).join('');
+    input = input.split(op).join('')
   }
-  return input;
+  return input
 }
 
 export const removeDuplicateChars = (input: string): string => {
-  return Array.from(new Set(input.split(''))).join('');
+  return Array.from(new Set(input.split(''))).join('')
 }
 
 export const extractRanges = (input: string): [string, string[]] => {
-  const ranges = input.match(/\[(.*?)]/g) || [];
-  input = input.replace(/\[(.*?)]/g, '');
-  return [input, ranges];
+  const ranges = input.match(/\[(.*?)]/g) || []
+  input = input.replace(/\[(.*?)]/g, '')
+  return [input, ranges]
 }
 
 // Exclusions are denoted with ! followed by the character to exclude
 export const extractAndRemoveExclusions = (input: string): [string, string] => {
-  const exclusionMatches = input.match(/!+([^!])/g) || [];
+  const exclusionMatches = input.match(/!+([^!])/g) || []
   for (const match of exclusionMatches) {
-    input = input.replace(match, '');
+    input = input.replace(match, '')
   }
-  input = input.replace(/!+/g, '');
-  const uniqueExclusions = Array.from(new Set(exclusionMatches.map(match => '!' + match[match.length - 1]))).join('');
-  return [input, uniqueExclusions];
+  input = input.replace(/!+/g, '')
+  const uniqueExclusions = Array.from(new Set(exclusionMatches.map(match => '!' + match[match.length - 1]))).join('')
+  return [input, uniqueExclusions]
 }
 
-
+// Extracts ranges and exclusion pairs to readd to return value
+// Removes whitespace, or operators, and duplicates
 // If the input is 'a[w-z]a!!b', the output will be 'a!b[w-z]'
 export const formatInput = (input: string, orOperator: string): string => {
-  input = removeWhitespace(input);
-  input = removeOrOperators(input, orOperator);
+  const [inputWithoutRanges, ranges] = extractRanges(input)
+  const [inputWithoutExclusions, uniqueExclusions] = extractAndRemoveExclusions(inputWithoutRanges)
+  input = removeWhitespace(inputWithoutExclusions)
+  input = removeOrOperators(input, orOperator)
   input = removeDuplicateChars(input)
-  const [inputWithoutRanges, ranges] = extractRanges(input);
-  const [finalInput, uniqueExclusions] = extractAndRemoveExclusions(inputWithoutRanges);
-  return `${finalInput}${uniqueExclusions}${ranges.join('')}`;
+
+  return `${input}${uniqueExclusions}${ranges.join('')}`
 }

--- a/packages/simulation/src/FSASearch.ts
+++ b/packages/simulation/src/FSASearch.ts
@@ -3,7 +3,7 @@ import { FSAAutomataTransition } from 'frontend/src/types/ProjectTypes'
 import { extractSymbolsToExclude } from 'frontend/src/util/stringManipulations'
 
 export class FSAState extends State {
-  constructor(
+  constructor (
     id: number,
     isFinal: boolean,
     readonly read: string | null = null,
@@ -12,17 +12,17 @@ export class FSAState extends State {
     super(id, isFinal)
   }
 
-  key() {
+  key () {
     return String(this.id + this.remaining)
   }
 }
 
 export class FSAGraph extends Graph<FSAState, FSAAutomataTransition> {
-  public isFinalState(node: Node<FSAState>) {
+  public isFinalState (node: Node<FSAState>) {
     return node.state.isFinal && node.state.remaining.length === 0
   }
 
-  public getSuccessors(node: Node<FSAState>) {
+  public getSuccessors (node: Node<FSAState>) {
     const transitions = this.transitions.filter(
       (transition) => transition.from === node.state.id
     )

--- a/packages/simulation/src/PDASearch.ts
+++ b/packages/simulation/src/PDASearch.ts
@@ -1,6 +1,7 @@
 import { Graph, Node, State } from './interfaces/graph'
 import { Stack } from './graph'
 import { PDAAutomataTransition } from 'frontend/src/types/ProjectTypes'
+import { extractSymbolsToExclude } from 'frontend/src/util/stringManipulations'
 
 export class PDAState extends State {
   constructor (
@@ -43,13 +44,15 @@ export class PDAGraph extends Graph<PDAState, PDAAutomataTransition> {
       let invalidPop = false
       const lambdaTransition = transition.read.length === 0
       const symbol = node.state.remaining[0]
+      const symbolsToExclude = extractSymbolsToExclude(transition.read)
       const pop = transition.pop
       const push = transition.push
 
       // If there is no next state
       if (
-        nextState === undefined ||
-                (!lambdaTransition && !transition.read.includes(symbol))
+        (nextState === undefined) ||
+        ((symbolsToExclude.length === 0) && (!transition.read.includes(symbol))) ||
+        ((symbolsToExclude.length > 0) && (symbolsToExclude.includes(symbol)))
       ) {
         continue
       }

--- a/packages/simulation/src/PDASearch.ts
+++ b/packages/simulation/src/PDASearch.ts
@@ -44,15 +44,16 @@ export class PDAGraph extends Graph<PDAState, PDAAutomataTransition> {
       let invalidPop = false
       const lambdaTransition = transition.read.length === 0
       const symbol = node.state.remaining[0]
+      // Get any symbols preceded by an exclusion operator
       const symbolsToExclude = extractSymbolsToExclude(transition.read)
       const pop = transition.pop
       const push = transition.push
 
       // If there is no next state
       if (
-        (nextState === undefined) ||
-        ((symbolsToExclude.length === 0) && (!transition.read.includes(symbol))) ||
-        ((symbolsToExclude.length > 0) && (symbolsToExclude.includes(symbol)))
+        nextState === undefined ||
+        (!lambdaTransition && !transition.read.includes(symbol) && (symbolsToExclude.length === 0)) ||
+        (!lambdaTransition && (symbolsToExclude.length > 0) && (symbolsToExclude.includes(symbol)))
       ) {
         continue
       }

--- a/packages/simulation/src/TMSearch.ts
+++ b/packages/simulation/src/TMSearch.ts
@@ -4,7 +4,7 @@ import { TMAutomataTransition } from 'frontend/src/types/ProjectTypes'
 import { extractSymbolsToExclude } from 'frontend/src/util/stringManipulations'
 
 export class TMState extends State {
-  constructor(
+  constructor (
     id: number,
     isFinal: boolean,
     public tape?: Tape
@@ -12,20 +12,20 @@ export class TMState extends State {
     super(id, isFinal)
   }
 
-  key() {
+  key () {
     const traceAdd = this.tape.trace.toString() ?? ''
     return String(this.id + ',' + this.tape.pointer + ',' + traceAdd)
   }
 }
 
 export class TMGraph extends Graph<TMState, TMAutomataTransition> {
-  public isFinalState(node: Node<TMState>) {
+  public isFinalState (node: Node<TMState>) {
     return (
       node.state.isFinal
     )
   }
 
-  public getSuccessors(node: Node<TMState>) {
+  public getSuccessors (node: Node<TMState>) {
     const transitions = this.transitions.filter(
       (transition) => transition.from === node.state.id
     )
@@ -75,7 +75,7 @@ export class TMGraph extends Graph<TMState, TMAutomataTransition> {
     return successors
   }
 
-  private progressTape(node: Node<TMState>, transition: TMAutomataTransition) {
+  private progressTape (node: Node<TMState>, transition: TMAutomataTransition) {
     const tapeTrace = node.state.tape.trace
     const write = transition.write
     const direction = transition.direction

--- a/packages/simulation/src/TMSearch.ts
+++ b/packages/simulation/src/TMSearch.ts
@@ -58,7 +58,6 @@ export class TMGraph extends Graph<TMState, TMAutomataTransition> {
           nextState.id,
           nextState.isFinal,
           nextTape
-          // read: symbol
         )
         const successor = new Node(graphState, node)
         successors.push(successor)

--- a/packages/simulation/src/TMSearch.ts
+++ b/packages/simulation/src/TMSearch.ts
@@ -1,7 +1,6 @@
 import { Tape } from './graph'
 import { Graph, Node, State } from './interfaces/graph'
 import { TMAutomataTransition } from 'frontend/src/types/ProjectTypes'
-
 import { extractSymbolsToExclude } from 'frontend/src/util/stringManipulations'
 
 export class TMState extends State {
@@ -43,6 +42,7 @@ export class TMGraph extends Graph<TMState, TMAutomataTransition> {
       const symbol = tapeTrace[tapePointer] ?? ''
       let nextTape = this.progressTape(node, transition)
 
+      // Get any symbols preceded by an exclusion operator
       const symbolsToExclude = extractSymbolsToExclude(transition.read)
       // If there is no next state
       if (

--- a/packages/simulation/src/parseGraph.ts
+++ b/packages/simulation/src/parseGraph.ts
@@ -65,5 +65,10 @@ export const expandReadSymbols = (read: string): string => {
   // Find literals
   const symbols = read.split('').filter((s) => LITERAL_REG.test(s))
 
-  return Array.from(new Set([...symbols, ...rangeSymbols])).sort().join('')
+  if (read.includes('!')) {
+    // Don't sort if there is an exclusion operator present
+    return Array.from(new Set([...symbols, ...rangeSymbols])).join('')
+  } else {
+    return Array.from(new Set([...symbols, ...rangeSymbols])).sort().join('')
+  }
 }

--- a/packages/simulation/src/utils.ts
+++ b/packages/simulation/src/utils.ts
@@ -42,7 +42,14 @@ export type TransitionMapping<P extends ProjectGraph> =
  * @see expandReadSymbols
  */
 export const expandTransitions = <T extends BaseAutomataTransition>(transitions: T[]): T[] => {
-  return transitions.map(t => ({ ...t, read: expandReadSymbols(t.read ?? '') }))
+  return transitions.map(t => {
+    if (t.read && t.read.startsWith('!') && t.read.length > 1) {
+      // Skip expansion for exclusion inputs
+      return t
+    }
+    // Otherwise, proceed with the expansion
+    return { ...t, read: expandReadSymbols(t.read ?? '') }
+  })
 }
 
 /**

--- a/packages/simulation/src/validTransitions.ts
+++ b/packages/simulation/src/validTransitions.ts
@@ -2,6 +2,7 @@ import { ReadSymbol, StateID } from './graph'
 import closureWithPredicate from './closureWithPredicate'
 import { BaseAutomataTransition, ProjectGraph } from 'frontend/src/types/ProjectTypes'
 import { TransitionMapping } from './utils'
+import { extractSymbolsToExclude } from 'frontend/src/util/stringManipulations'
 
 export type ValidTransition<T extends BaseAutomataTransition> = { transition: T, trace: { to: number, read: string }[]}
 
@@ -19,16 +20,26 @@ export const validTransitions = <P extends ProjectGraph, T extends TransitionMap
   const closure = Array.from(closureWithPredicate(graph, currentStateID, tr => tr.read.length === 0))
 
   // Find direct non-lambda transitions
-  const directTransitions = graph.transitions
-    .filter(transition => transition.from === currentStateID && transition.read.includes(nextRead))
+  const directTransitions: ValidTransition<T>[] = graph.transitions
+    .filter(transition => {
+      const symbolsToExclude = extractSymbolsToExclude(transition.read)
+      return transition.from === currentStateID &&
+        ((transition.read.includes(nextRead) && symbolsToExclude.length === 0) ||
+        (symbolsToExclude.length > 0 && !symbolsToExclude.includes(nextRead)))
+    })
     .map(transition => ({ transition, trace: [] } as ValidTransition<T>))
 
   // Find transitions from states in lambda closure that we can take
-  const indirectTransitions = closure
-    .map(({ state, transitions }) => graph.transitions
-      .filter(transition => transition.from === state && transition.read.includes(nextRead))
-      .map((transition: T) => ({ transition, trace: transitions } as ValidTransition<T>)))
-    .reduce((a, b) => [...a, ...b], [])
+  const indirectTransitions = closure.map(({ state, transitions }) => {
+    return graph.transitions
+      .filter(transition => {
+        const symbolsToExclude = extractSymbolsToExclude(transition.read)
+        return transition.from === state &&
+          ((transition.read.includes(nextRead) && symbolsToExclude.length === 0) ||
+          (symbolsToExclude.length > 0 && !symbolsToExclude.includes(nextRead)))
+      })
+      .map((transition: T) => ({ transition, trace: transitions } as ValidTransition<T>))
+  }).reduce((a, b) => [...a, ...b], [])
 
   // Find transitions to final states in lambda closure
   const finalTransitions = closure

--- a/packages/simulation/tests/exclusionInputs.test.ts
+++ b/packages/simulation/tests/exclusionInputs.test.ts
@@ -1,0 +1,109 @@
+/// <reference types="jest-extended" />
+
+import { extractSymbolsToExclude, exclusionInput } from 'frontend/src/util/stringManipulations'
+
+/**
+ * Check that an input is expanded how we expect it to
+ * @param input The string that we are testing
+ * @param expected What we expect to extract from the input
+ */
+const expectExtraction = (input: string, expected: string[]) => {
+  expect(extractSymbolsToExclude(input)).toEqual(expected)
+}
+
+const expectExclusionFormat = (input: string, expected: string) => {
+  expect(exclusionInput(input)).toEqual(expected)
+}
+
+describe('Extract exclusion symbols', () => {
+  test('Should extract letter preceded by exclusion operator into a string array', () => {
+    expectExtraction('!a', ['a'])
+  })
+
+  test('Should extract number preceded by exclusion operator into a string array', () => {
+    expectExtraction('!2', ['2'])
+  })
+
+  test('Should extract special character preceded by exclusion operator into a string array', () => {
+    expectExtraction('!*', ['*'])
+  })
+
+  test('Should extract letters preceded by exclusion operator into a string array', () => {
+    // Ranges are expanded to this format prior to being extracted
+    expectExtraction('!abcd', ['a', 'b', 'c', 'd'])
+  })
+})
+
+describe('Exclusion extraction edge cases', () => {
+  test('Lone exclusion operator should return empty array', () => {
+    expectExtraction('!', [])
+  })
+
+  test('Lambda input should return empty array', () => {
+    expectExtraction('', [])
+  })
+
+  test('Exclusion operator before unpaired bracket should return array containing [', () => {
+    expectExtraction('![ ', ['['])
+  })
+})
+
+describe('Extract excluded symbols from expression in parentheses', () => {
+  test('Should extract an array containing a and b from !(a&b)', () => {
+    expectExtraction('!(a&b)', ['a', 'b'])
+  })
+
+  test('Should extract an array containing a,b,c,d,e from !(a&b&c&d&e)', () => {
+    expectExtraction('!(a&b&c&d&e)', ['a', 'b', 'c', 'd', 'e'])
+  })
+})
+
+describe('Format exclusions', () => {
+  test('Should only return the first excluded symbol', () => {
+    expectExclusionFormat('!a!b', '!a')
+  })
+
+  test('No change to correctly formatted single character exclusion', () => {
+    expectExclusionFormat('!x', '!x')
+  })
+
+  test('No change to correctly formatted exclusion expression', () => {
+    expectExclusionFormat('!(1&2&3)', '!(1&2&3)')
+  })
+
+  test('Extraneous characters should be removed', () => {
+    expectExclusionFormat('7b!a5', '!a')
+  })
+
+  test('Extraneous characters should be removed around expression', () => {
+    expectExclusionFormat('7b!(8&b)a5', '!(8&b)')
+  })
+})
+
+describe('Format exclusion range', () => {
+  test('Exclusion operator should be kept in front of range', () => {
+    expectExclusionFormat('![0-4]', '![0-4]')
+  })
+
+  test('Should remove any excluded range beyond the first', () => {
+    expectExclusionFormat('![a-d]![e-g]', '![a-d]')
+  })
+
+  test('Should remove any extraneous characters around excluded range', () => {
+    expectExclusionFormat('abc![x-z]*?', '![x-z]')
+  })
+})
+
+describe('Format exclusion edge cases', () => {
+  test('Should only return one exlusion operator when multiple are present', () => {
+    expectExclusionFormat('!!!!!', '!')
+  })
+
+  test('Parentheses containing values not separated by & should return !(', () => {
+    expectExclusionFormat('!(ab)', '!(')
+  })
+
+  test('Unclosed parenthesis should return !(', () => {
+    expectExclusionFormat('!(a&b', '!(')
+  })
+})

--- a/packages/simulation/tests/exclusionInputs.test.ts
+++ b/packages/simulation/tests/exclusionInputs.test.ts
@@ -48,6 +48,16 @@ describe('Exclusion extraction edge cases', () => {
   })
 })
 
+describe('Extract excluded symbols from range', () => {
+  test('Should extract an array containing a, b, c from ![a-c]', () => {
+    expectExtraction('![a-c]', ['a', 'b', 'c'])
+  })
+
+  test('Should extract an array containing 5, 6, 7, 8 from ![5-8]', () => {
+    expectExtraction('![5-8]', ['5', '6', '7', '8'])
+  })
+})
+
 describe('Extract excluded symbols from expression in parentheses', () => {
   test('Should extract an array containing a and b from !(a&b)', () => {
     expectExtraction('!(a&b)', ['a', 'b'])
@@ -95,7 +105,7 @@ describe('Format exclusion range', () => {
 })
 
 describe('Format exclusion edge cases', () => {
-  test('Should only return one exlusion operator when multiple are present', () => {
+  test('Should only return one exclusion operator when multiple are present', () => {
     expectExclusionFormat('!!!!!', '!')
   })
 

--- a/packages/simulation/tests/expandReadSymbols.test.ts
+++ b/packages/simulation/tests/expandReadSymbols.test.ts
@@ -39,8 +39,8 @@ describe('Expand literals', () => {
     expectExpansion('abb', 'ab')
   })
 
-  test('Should pass through !@#$%^&*()_+-=', () => {
-    expectExpansion('!@#$%^&*()_+-=', '!#$%&()*+-=@^_')
+  test('Should not sort when exclusion operator present !@#$%^&*()_+-=', () => {
+    expectExpansion('!@#$%^&*()_+-=', '!@#$%^&*()_+-=')
   })
 
   test('Return empty for zero-length string', () => {

--- a/packages/simulation/tests/graphs/exclusionTransitions.json
+++ b/packages/simulation/tests/graphs/exclusionTransitions.json
@@ -1,0 +1,73 @@
+{
+  "projectType": "FSA",
+  "_id": "92d351d7-e7d6-4f56-924c-fa350c4c80e0",
+  "states": [
+    {
+      "x": 180,
+      "y": 270,
+      "id": 0,
+      "isFinal": false
+    },
+    {
+      "x": 375,
+      "y": 270,
+      "id": 1,
+      "isFinal": false
+    },
+    {
+      "x": 600,
+      "y": 270,
+      "id": 2,
+      "isFinal": false
+    },
+    {
+      "x": 840,
+      "y": 270,
+      "id": 3,
+      "isFinal": true
+    }
+  ],
+  "transitions": [
+    {
+      "from": 0,
+      "to": 1,
+      "id": 0,
+      "read": "!a"
+    },
+    {
+      "from": 1,
+      "to": 2,
+      "id": 1,
+      "read": "!(1&2&3)"
+    },
+    {
+      "from": 2,
+      "to": 3,
+      "id": 2,
+      "read": "![a-z]"
+    }
+  ],
+  "comments": [],
+  "simResult": [],
+  "tests": {
+    "single": "",
+    "batch": [
+      ""
+    ]
+  },
+  "initialState": 0,
+  "meta": {
+    "name": "Exclusion Transitions",
+    "dateCreated": 1696317531949,
+    "dateEdited": 1696317531949,
+    "version": "1.0.0",
+    "automatariumVersion": "1.0.0"
+  },
+  "config": {
+    "type": "FSA",
+    "statePrefix": "q",
+    "orOperator": "|",
+    "acceptanceCriteria": "both",
+    "color": "orange"
+  }
+}

--- a/packages/simulation/tests/simulateFSA.test.ts
+++ b/packages/simulation/tests/simulateFSA.test.ts
@@ -294,10 +294,10 @@ describe('Automata dib-end-lambda', () => {
   })
 })
 
-// Accepts 3-character strings not starting with 'a', without '123' as the second character, 
+// Accepts 3-character strings not starting with 'a', without '123' as the second character,
 // and ending in a non-alphabetical character
 describe('Exclusion automata', () => {
-  test('Rejects "abc" with correct trace' , () => {
+  test('Rejects "abc" with correct trace', () => {
     const { accepted, trace } = simulateFSA(exclusionTransitions as FSAProjectGraph, 'abc')
     const to = trace.map(step => step.to)
     const read = trace.map(step => step.read)
@@ -341,5 +341,4 @@ describe('Exclusion automata', () => {
     expect(to).toStrictEqual([0, 1, 2, 3])
     expect(read).toStrictEqual([null, '1', '0', '1'])
   })
-
 })

--- a/packages/simulation/tests/simulateFSA.test.ts
+++ b/packages/simulation/tests/simulateFSA.test.ts
@@ -11,6 +11,7 @@ import dibSplitJoin from './graphs/dib-split-join.json'
 import dib from './graphs/dib.json'
 import lambdaOnly from './graphs/lambda-only.json'
 import dibEndLambda from './graphs/dib-end-lambda.json'
+import exclusionTransitions from './graphs/exclusionTransitions.json'
 import { FSAProjectGraph } from 'frontend/src/types/ProjectTypes'
 
 // Accepts dib or dip with even number of ps
@@ -291,4 +292,54 @@ describe('Automata dib-end-lambda', () => {
     expect(to).toStrictEqual([0, 1, 2])
     expect(read).toStrictEqual([null, 'd', 'i'])
   })
+})
+
+// Accepts 3-character strings not starting with 'a', without '123' as the second character, 
+// and ending in a non-alphabetical character
+describe('Exclusion automata', () => {
+  test('Rejects "abc" with correct trace' , () => {
+    const { accepted, trace } = simulateFSA(exclusionTransitions as FSAProjectGraph, 'abc')
+    const to = trace.map(step => step.to)
+    const read = trace.map(step => step.read)
+    expect(accepted).toBeFalse()
+    expect(to).toStrictEqual([0])
+    expect(read).toStrictEqual([null])
+  })
+
+  test('Rejects "b100" with correct trace', () => {
+    const { accepted, trace } = simulateFSA(exclusionTransitions as FSAProjectGraph, 'b100')
+    const to = trace.map(step => step.to)
+    const read = trace.map(step => step.read)
+    expect(accepted).toBeFalse()
+    expect(to).toStrictEqual([0, 1])
+    expect(read).toStrictEqual([null, 'b'])
+  })
+
+  test('Rejects "123" with correct trace', () => {
+    const { accepted, trace } = simulateFSA(exclusionTransitions as FSAProjectGraph, '123')
+    const to = trace.map(step => step.to)
+    const read = trace.map(step => step.read)
+    expect(accepted).toBeFalse()
+    expect(to).toStrictEqual([0, 1])
+    expect(read).toStrictEqual([null, '1'])
+  })
+
+  test('Rejects "fsa" with correct trace', () => {
+    const { accepted, trace } = simulateFSA(exclusionTransitions as FSAProjectGraph, 'fsa')
+    const to = trace.map(step => step.to)
+    const read = trace.map(step => step.read)
+    expect(accepted).toBeFalse()
+    expect(to).toStrictEqual([0, 1, 2])
+    expect(read).toStrictEqual([null, 'f', 's'])
+  })
+
+  test('Accepts "101" with correct trace', () => {
+    const { accepted, trace } = simulateFSA(exclusionTransitions as FSAProjectGraph, '101')
+    const to = trace.map(step => step.to)
+    const read = trace.map(step => step.read)
+    expect(accepted).toBeTrue()
+    expect(to).toStrictEqual([0, 1, 2, 3])
+    expect(read).toStrictEqual([null, '1', '0', '1'])
+  })
+
 })


### PR DESCRIPTION
Closes #425 

This update introduces the capability to create exclusion inputs within transitions using a NOT operator (!). For instance, with an input such as !a, all symbols except 'a' are permissible. Users have three different ways to implement this feature:
1. Prefix a single character with !, e.g. !z
2. Apply ! before a character range, e.g. ![a-z]
3. Apply ! before expressions encapsulated in parentheses, where values are connected with an AND operator (&), e.g. !(a&c&d)

<img width="652" alt="Screen Shot 2023-10-11 at 15 19 07" src="https://github.com/automatarium/automatarium/assets/113315517/f702e13c-10ec-4042-bf83-beb4fd1fef62">

Changes:

- Input expressions prefixed with ! will be treated uniquely, permitting only symbols that are not present in the read

- Added new string manipulation functions that facilitate the formatting of exclusion inputs and the extraction of input symbols from a given string 

- Added tests to validate the formatting and extraction processes related to exclusion inputs

- Added tests to verify the functionality of exclusion transitions

-  Revised the info tab to appropriately display exclusion expressions

<img width="370" alt="Screen Shot 2023-10-11 at 15 19 21" src="https://github.com/automatarium/automatarium/assets/113315517/975a840e-314f-4e04-b925-54a264846bf5">