### PR TITLE
Update keyboard shortcuts

### DIFF
--- a/frontend/src/components/Menubar/menus.ts
+++ b/frontend/src/components/Menubar/menus.ts
@@ -188,6 +188,10 @@ const menus: ContextItems = [
         action: 'OPEN_DOCS'
       },
       {
+        label: 'Tutorial videos',
+        action: 'TUTORIAL_VIDEOS'
+      },
+      {
         label: 'Keyboard shortcuts',
         action: 'KEYBOARD_SHORTCUTS'
       },

--- a/frontend/src/components/Menubar/menus.ts
+++ b/frontend/src/components/Menubar/menus.ts
@@ -155,6 +155,10 @@ const menus: ContextItems = [
       {
         label: 'File options',
         action: 'FILE_OPTIONS'
+      },
+      {
+        label: 'Templates',
+        action: 'TEMPLATES'
       }
     ]
   },

--- a/frontend/src/components/Sidepanel/Panels/index.ts
+++ b/frontend/src/components/Sidepanel/Panels/index.ts
@@ -1,4 +1,4 @@
-export type SidePanelKey = 'test' | 'step' | 'about' | 'options'
+export type SidePanelKey = 'test' | 'step' | 'about' | 'options' | 'templates'
 
 export { default as TestingLab } from './TestingLab/TestingLab'
 export { default as SteppingLab } from './SteppingLab/SteppingLab'

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -33,7 +33,7 @@ export const formatHotkey = (hotkey: HotKey): string => [
   hotkey.meta && (isWindows ? (isWindows ? 'Ctrl' : '⌃') : '⌘'),
   hotkey.alt && (isWindows ? 'Alt' : '⌥'),
   hotkey.shift && (isWindows ? 'Shift' : '⇧'),
-  hotkey.key?.toUpperCase()
+  hotkey.key === 'Escape' ? 'ESC' : hotkey.key?.toUpperCase()
 ].filter(Boolean).join(isWindows ? '+' : ' ')
 
 /**
@@ -213,7 +213,7 @@ const useActions = (registerHotkeys = false) => {
       handler: selectAll
     },
     SELECT_NONE: {
-      hotkeys: [{ key: 'a', shift: true, meta: true }],
+      hotkeys: [{ key: 'Escape' }],
       handler: selectNone
     },
     DELETE: {

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -306,6 +306,9 @@ const useActions = (registerHotkeys = false) => {
     OPEN_DOCS: {
       handler: () => window.open('https://github.com/automatarium/automatarium/wiki', '_blank')
     },
+    TUTORIAL_VIDEOS: {
+      handler: () => window.open('/tutorials', '_blank')
+    },
     KEYBOARD_SHORTCUTS: {
       hotkeys: [{ key: '/', meta: true }],
       handler: () => dispatchCustomEvent('modal:shortcuts', null)

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -288,6 +288,10 @@ const useActions = (registerHotkeys = false) => {
       hotkeys: [{ key: '4', shift: true }],
       handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'options' })
     },
+    TEMPLATES: {
+      hotkeys: [{ key: '5', shift: true }],
+      handler: () => dispatchCustomEvent('sidepanel:open', { panel: 'templates' })
+    },
     CONVERT_TO_DFA: {
       disabled: () => projectType !== 'FSA' || project.initialState === null,
       handler: () => {

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -212,6 +212,10 @@ const useActions = (registerHotkeys = false) => {
       hotkeys: [{ key: 'a', meta: true }],
       handler: selectAll
     },
+    SELECT_NONE: {
+      hotkeys: [{ key: 'a', shift: true, meta: true }],
+      handler: selectNone
+    },
     DELETE: {
       hotkeys: [{ key: 'Delete' }, { key: 'Backspace' }],
       handler: () => {

--- a/frontend/src/pages/ShortcutGuide/ShortcutGuide.tsx
+++ b/frontend/src/pages/ShortcutGuide/ShortcutGuide.tsx
@@ -162,12 +162,20 @@ const shortcuts: Category[] = [
         action: 'TESTING_LAB'
       },
       {
+        label: 'Stepping lab',
+        action: 'STEPPING_LAB'
+      },
+      {
         label: 'File info',
         action: 'FILE_INFO'
       },
       {
         label: 'File options',
         action: 'FILE_OPTIONS'
+      },
+      {
+        label: 'Templates',
+        action: 'TEMPLATES'
       },
       {
         label: 'Move view',


### PR DESCRIPTION
Added the keyboard shortcut Shift+5 for toggling the Templates panel in preparation for recording a short tutorial video. Updated the guide to include the Stepping Lab and Templates shortcuts.

Noticed that 'Clear Selection' was listed in the Shortcut guide without a corresponding shortcut, so added 'Escape'.

Also added a Help menu option for accessing tutorial videos.