### PR TITLE
Stop transition editing deleting transition on cancel

### DIFF
--- a/frontend/src/components/InputDialogs/InputDialogs.tsx
+++ b/frontend/src/components/InputDialogs/InputDialogs.tsx
@@ -97,14 +97,17 @@ const InputDialogs = () => {
   const orOperator = useProjectStore(s => s.project.config.orOperator) ?? '|'
   const hideDialog = useCallback(() => setDialog({ ...dialog, visible: false }), [dialog])
   const focusInput = useCallback(() => setTimeout(() => inputRef.current?.focus(), 100), [inputRef.current])
+  const [isNew, setIsNew] = useState(true)
   const arr = [inputWriteRef.current, inputDirectionRef.current, inputRef.current]
-  useEvent('editTransition', ({ detail: { id } }) => {
+
+  useEvent('editTransition', ({ detail: { id, new: isNewTransition } }) => {
     const { states, transitions } = useProjectStore.getState()?.project ?? {}
     const transition = transitions.find(t => t.id === id)
     // Find midpoint of transition in screen space
     const pos = locateTransition(transition, states)
     const midPoint = lerpPoints(pos.from, pos.to, 0.5)
     const screenMidPoint = viewToScreenSpace(midPoint.x, midPoint.y)
+    setIsNew(isNewTransition ?? true) // Default a.k.a. previous functionality assumes new
     switch (projectType) {
       case 'TM':
         assertType<TMAutomataTransition>(transition)
@@ -275,7 +278,7 @@ const InputDialogs = () => {
     visible: dialog.visible,
     onClose: () => {
       hideDialog()
-      if (['FSATransition', 'PDATransition', 'TMTransition'].includes(dialog.type)) {
+      if (isNew && ['FSATransition', 'PDATransition', 'TMTransition'].includes(dialog.type)) {
         removeTransitions([dialog.id])
       }
     },

--- a/frontend/src/components/TransitionSet/TransitionSet.tsx
+++ b/frontend/src/components/TransitionSet/TransitionSet.tsx
@@ -172,7 +172,7 @@ const Transition = ({
       ctx: t.id
     })
   const handleTransitionDoubleClick = (t: PositionedTransition) => (e: MouseEvent) => {
-    dispatchCustomEvent('editTransition', { id: t.id })
+    dispatchCustomEvent('editTransition', { id: t.id, new: false })
     // Needs to be a different event since this takes the whole transition object but editTransition only supports IDs
     // The need for the whole object is so that it is inline with the other events
     dispatchCustomEvent('transition:dblclick', { originalEvent: e, transition: t, ctx: t.id })
@@ -188,7 +188,7 @@ const Transition = ({
 
   const handleEdgeDoubleClick = (e: MouseEvent) => {
     // Edit only first transition on dbl-click
-    dispatchCustomEvent('editTransition', { id: transitions[0].id })
+    dispatchCustomEvent('editTransition', { id: transitions[0].id, new: false })
     dispatchCustomEvent('edge:dblclick', { originalEvent: e, transitions, ctx: transitions[0]?.id ?? null })
   }
 

--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -372,7 +372,7 @@ const useActions = (registerHotkeys = false) => {
       handler: () => {
         const selectedTransition = useSelectionStore.getState().selectedTransitions?.[0]
         if (selectedTransition === undefined) return
-        window.setTimeout(() => dispatchCustomEvent('editTransition', { id: selectedTransition }), 100)
+        window.setTimeout(() => dispatchCustomEvent('editTransition', { id: selectedTransition, new: false }), 100)
       }
     },
     EDIT_TRANSITIONS_GROUP: {

--- a/frontend/src/hooks/useEvent.ts
+++ b/frontend/src/hooks/useEvent.ts
@@ -24,7 +24,7 @@ export type TransitionHandleEventData = { originalEvent: MouseEvent, transitionI
  * If making a custom event just add it here first
  */
 export interface CustomEvents {
-  'editTransition': { id: number },
+  'editTransition': { id: number, new?: boolean },
   'editComment': { id?: number, x: number, y: number },
   'editStateName': { id: number },
   'editStateLabel': { id: number },


### PR DESCRIPTION
Closes #449.

Edit transition receives an optional flag specifying whether a transtion being edited is a new transition or not. The input dialog receives that and does not go through with he deletion if the edit event is not for a new dialog. Defaults to `true`, which is the previous behaviour, so should not regress on any other part of the app.