### PR TITLE
Completion of issue #359

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
@@ -175,8 +175,6 @@ const TestingLab = () => {
   const noInitialState = [null, undefined].includes(graph?.initialState) || !graph?.states.find(s => s.id === graph?.initialState)
   const noFinalState = !graph?.states.find(s => s.isFinal)
   const warnings = []
-  if (noInitialState) { warnings.push('There is no initial state') }
-  if (noFinalState) { warnings.push('There are no final states') }
 
   // Update disconnected warning
   const pathToFinal = useMemo(() => {
@@ -189,7 +187,10 @@ const TestingLab = () => {
     }
   }, [graph])
   // Also part of #359 - No need to flag that there is a disconnection if # states <= 1
-  if (!pathToFinal && (graph.states.length > 1)) { warnings.push('There is no path to a final state') }
+  if (noInitialState) { warnings.push('There is no initial state') }
+  if (noFinalState) { warnings.push('There are no final states') }
+  else if (!pathToFinal) { warnings.push('There is no path to final state') }
+  
 
   // :^)
   const dibEgg = useDibEgg()

--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
@@ -178,19 +178,13 @@ const TestingLab = () => {
 
   // Update disconnected warning
   const pathToFinal = useMemo(() => {
-    // Hardcoded solution to #359 - Return that a path exists for a graph with one state that is both initial and final without transitions
-    if (graph.states.length === 1 && !noInitialState && !noFinalState && graph.transitions.length === 0) {
-      return true
-    } else {
-      const closure = closureWithPredicate(graph, graph.initialState, () => true)
-      return Array.from(closure).some(({ state }) => graph.states.find(s => s.id === state)?.isFinal)
-    }
+    // Solution to #359 - Concat the intial state to solve the problem that a legal 1 state (both initial and final) 0 transition machine can accept λ
+    const closure = closureWithPredicate(graph, graph.initialState, () => true)
+    return Array.from(closure).concat({ state: graph.initialState, transitions: [] }).some(({ state }) => graph.states.find(s => s.id === state)?.isFinal)
   }, [graph])
   // Also part of #359 - No need to flag that there is a disconnection if # states <= 1
   if (noInitialState) { warnings.push('There is no initial state') }
-  if (noFinalState) { warnings.push('There are no final states') }
-  else if (!pathToFinal) { warnings.push('There is no path to final state') }
-  
+  if (noFinalState) { warnings.push('There are no final states') } else if (!pathToFinal) { warnings.push('There is no path to final state') }
 
   // :^)
   const dibEgg = useDibEgg()

--- a/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
+++ b/frontend/src/components/Sidepanel/Panels/TestingLab/TestingLab.tsx
@@ -180,10 +180,16 @@ const TestingLab = () => {
 
   // Update disconnected warning
   const pathToFinal = useMemo(() => {
-    const closure = closureWithPredicate(graph, graph.initialState, () => true)
-    return Array.from(closure).some(({ state }) => graph.states.find(s => s.id === state)?.isFinal)
+    // Hardcoded solution to #359 - Return that a path exists for a graph with one state that is both initial and final without transitions
+    if (graph.states.length === 1 && !noInitialState && !noFinalState && graph.transitions.length === 0) {
+      return true
+    } else {
+      const closure = closureWithPredicate(graph, graph.initialState, () => true)
+      return Array.from(closure).some(({ state }) => graph.states.find(s => s.id === state)?.isFinal)
+    }
   }, [graph])
-  if (!pathToFinal) { warnings.push('There is no path to a final state') }
+  // Also part of #359 - No need to flag that there is a disconnection if # states <= 1
+  if (!pathToFinal && (graph.states.length > 1)) { warnings.push('There is no path to a final state') }
 
   // :^)
   const dibEgg = useDibEgg()


### PR DESCRIPTION
As title. Hardcoded a return of true in _pathToFinal_ for the edge case, also removed the path warning that was flagging for machines with 0 or 1 state(s), since a path cannot form in such number of states.

I'll leave the philosophical debate of "is it _really_ a path without transitions?"  to future groups.