### PR TITLE
Remove the m

### DIFF
--- a/frontend/src/pages/Editor/Editor.tsx
+++ b/frontend/src/pages/Editor/Editor.tsx
@@ -122,7 +122,6 @@ const Editor = () => {
       <FinalStatePopup />
 
       <ExportImage />
-m
       <ShareUrl />
 
       <TemplateDelConfDialog


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1f28702e-5d2b-4039-a9df-351445980a1a)
Don't know if bug or feature, but this removes the 'm' thats in the bottom left of the editor