### PR TITLE
Update share URL when opening export modal

### DIFF
--- a/frontend/src/components/ShareUrl/ShareUrl.tsx
+++ b/frontend/src/components/ShareUrl/ShareUrl.tsx
@@ -14,15 +14,17 @@ const ShareUrl = () => {
 
   const [base64Project, setBase64Project] = useState('')
 
-  if (base64Project === '') {
-    encodeData(project).then(setBase64Project)
-  }
-
   const shareRawLink = `${window.location.origin}/share/raw/${base64Project}`
 
   const [exportUrlOpen, setExportUrlOpen] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)
   const [dataCopySuccess, setDataCopySuccess] = useState(false)
+
+  useEffect(() => {
+    if (exportUrlOpen) {
+      encodeData(project).then(setBase64Project)
+    }
+  }, [exportUrlOpen])
 
   const handleClose = () => {
     setExportUrlOpen(false)


### PR DESCRIPTION
Upon opening the share modal, the base 64 representing the project was only up to date as of the first load of the page.

This PR will update the share URL when the share button is pressed, meaning no more refreshing before sharing :)

Fixes #489