### PR TITLE
Fix project action colours

### DIFF
--- a/frontend/src/components/KebabMenu/KebabMenu.tsx
+++ b/frontend/src/components/KebabMenu/KebabMenu.tsx
@@ -12,8 +12,9 @@ const KebabMenu = (props: KebabProps) => {
       top: `${props.y}px`,
       left: `${props.x}px`,
       borderStyle: 'solid',
-      borderWidth: '0.15em',
-      borderColor: 'hsla(var(--primary-h), var(--primary-s), var(--primary-l), 0.9)'
+      borderWidth: '1px',
+      borderColor: 'var(--toolbar)',
+      boxShadow: '0 2px 5px rgba(0 0 0 / .3)'
     }}
     items={kebabContextItems}
   />

--- a/frontend/src/components/ProjectCard/ProjectCard.tsx
+++ b/frontend/src/components/ProjectCard/ProjectCard.tsx
@@ -5,7 +5,7 @@ import { Logo } from '/src/components'
 
 import { MoreVertical, Trash } from 'lucide-react'
 import { ButtonHTMLAttributes, Ref } from 'react'
-import { CardContainer, CardDetail, CardImage, SelectedTemplateOverlay, TitleAndKebab, TypeBadge } from './projectCardStyle'
+import { CardContainer, CardDetail, CardImage, SelectedTemplateOverlay, TitleWithAction, TypeBadge } from './projectCardStyle'
 import { ProjectType } from '/src/types/ProjectTypes'
 dayjs.extend(relativeTime)
 
@@ -36,7 +36,7 @@ const ProjectCard = ({ name, type, date, image, isSelectedTemplate = false, ...p
       {isSelectedTemplate && <SelectedTemplateOverlay/>}
     </CardImage>
     <CardDetail>
-      <TitleAndKebab>
+      <TitleWithAction>
         <strong>{name}</strong>
         {props.$istemplate
           ? <div>
@@ -46,10 +46,10 @@ const ProjectCard = ({ name, type, date, image, isSelectedTemplate = false, ...p
           </div>
           : <div>
             <a onClick={props.$kebabClick} ref={props.$kebabRef}>
-              <MoreVertical/>
+              <MoreVertical />
             </a>
           </div>}
-      </TitleAndKebab>
+      </TitleWithAction>
       {date && <span>{date instanceof dayjs ? dayjs().to(date) : date as string}</span>}
     </CardDetail>
   </CardContainer>

--- a/frontend/src/components/ProjectCard/projectCardStyle.ts
+++ b/frontend/src/components/ProjectCard/projectCardStyle.ts
@@ -71,7 +71,11 @@ export const TitleWithAction = styled('div')`
 
   a {
     color: var(--white);
-    opacity: 0.75;
+    opacity: 0.5;
+
+    &:hover {
+      opacity: 1;
+    }
   }
 `
 

--- a/frontend/src/components/ProjectCard/projectCardStyle.ts
+++ b/frontend/src/components/ProjectCard/projectCardStyle.ts
@@ -64,10 +64,15 @@ export const TypeBadge = styled('div')`
   font-weight: 600;
   opacity: .9;
 `
-export const TitleAndKebab = styled('div')`
+export const TitleWithAction = styled('div')`
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+
+  a {
+    color: var(--white);
+    opacity: 0.75;
+  }
 `
 
 export const CardDetail = styled('div')`


### PR DESCRIPTION
This PR will fix up some of the colours relating to the project actions - namely, the kebab menu and dropdown on the projects selection screen, and the trash icon on the templates component.

The full saturation brand colour (orange) should be reserved for primary buttons/actions as opposed to design elements or secondary actions.

Fixes #471 and #472.

Project page (images):
| Original | Updated |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/21d1281b-9d2b-4249-b13c-cc2e88a68bbd) | ![image](https://github.com/user-attachments/assets/41c48796-72fd-40dc-ba99-ffccef6c8617) |

Project page (videos)
| Original | Updated |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/3822b2d9-1557-46d8-b09f-2cc456153aeb"> | <video src="https://github.com/user-attachments/assets/675ffcb8-918c-4ebd-a573-78179e84c84f"> |

Templates:
| Original | Updated |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/61fe0b6e-daa9-4952-a161-20814ea4d23e) | ![image](https://github.com/user-attachments/assets/3cc30bce-6d3d-4171-8964-033599cdd23d) |


