### PR TITLE
Fix autosave status timing

### DIFF
--- a/frontend/src/components/Menubar/Menubar.tsx
+++ b/frontend/src/components/Menubar/Menubar.tsx
@@ -71,6 +71,8 @@ const Menubar = ({ isSaving }: { isSaving: boolean }) => {
 
   const projectName = useProjectStore(s => s.project?.meta?.name)
   const setProjectName = useProjectStore(s => s.setName)
+  const lastChangeDate = useProjectStore(s => s.lastChangeDate)
+  const lastSaveDate = useProjectStore(s => s.lastSaveDate)
   const setLastSaveDate = useProjectStore(s => s.setLastSaveDate)
   const upsertProject = useProjectsStore(s => s.upsertProject)
 
@@ -95,10 +97,10 @@ const Menubar = ({ isSaving }: { isSaving: boolean }) => {
   }
 
   useEvent('beforeunload', e => {
-    if (!isSaving) return
+    if (lastSaveDate > lastChangeDate) return
     e.preventDefault()
     return 'Your project isn\'t saved yet, are you sure you want to leave?'
-  }, [isSaving], { options: { capture: true }, target: window })
+  }, [lastSaveDate, lastChangeDate], { options: { capture: true }, target: window })
 
   return (
     <>
@@ -106,8 +108,9 @@ const Menubar = ({ isSaving }: { isSaving: boolean }) => {
         <Menu>
           <a href="/new" onClick={e => {
             e.preventDefault()
-            if (!isSaving) {
-              // If there are unsaved changes, save and then navigate
+            const project = useProjectStore.getState().project
+            const totalItems = project.comments.length + project.states.length + project.transitions.length
+            if (totalItems > 0) {
               saveProject()
             }
             navigate('/new')

--- a/frontend/src/components/Menubar/Menubar.tsx
+++ b/frontend/src/components/Menubar/Menubar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useMemo, HTMLAttributes } from 'react'
+import { useState, useEffect, useRef, HTMLAttributes } from 'react'
 import { useNavigate } from 'react-router-dom'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
@@ -61,7 +61,7 @@ const DropdownButton = ({ item, dropdown, setDropdown, ...props }: DropdownButto
   )
 }
 
-const Menubar = () => {
+const Menubar = ({ isSaving }: { isSaving: boolean }) => {
   const navigate = useNavigate()
   const [dropdown, setDropdown] = useState<string>()
 
@@ -73,11 +73,6 @@ const Menubar = () => {
   const setProjectName = useProjectStore(s => s.setName)
   const setLastSaveDate = useProjectStore(s => s.setLastSaveDate)
   const upsertProject = useProjectsStore(s => s.upsertProject)
-
-  const lastSaveDate = useProjectStore(s => s.lastSaveDate)
-  const lastChangeDate = useProjectStore(s => s.lastChangeDate)
-  // Determine whether saving
-  const isSaving = useMemo(() => !(!lastChangeDate || dayjs(lastSaveDate).isAfter(lastChangeDate)), [lastChangeDate, lastSaveDate])
 
   const handleEditProjectName = () => {
     setTitleValue(projectName ?? '')
@@ -111,7 +106,7 @@ const Menubar = () => {
         <Menu>
           <a href="/new" onClick={e => {
             e.preventDefault()
-            if (isSaving) {
+            if (!isSaving) {
               // If there are unsaved changes, save and then navigate
               saveProject()
             }

--- a/frontend/src/components/Menubar/Menubar.tsx
+++ b/frontend/src/components/Menubar/Menubar.tsx
@@ -75,6 +75,7 @@ const Menubar = ({ isSaving }: { isSaving: boolean }) => {
   const lastSaveDate = useProjectStore(s => s.lastSaveDate)
   const setLastSaveDate = useProjectStore(s => s.setLastSaveDate)
   const upsertProject = useProjectsStore(s => s.upsertProject)
+  const deleteProject = useProjectsStore(s => s.deleteProject)
 
   const handleEditProjectName = () => {
     setTitleValue(projectName ?? '')
@@ -112,6 +113,8 @@ const Menubar = ({ isSaving }: { isSaving: boolean }) => {
             const totalItems = project.comments.length + project.states.length + project.transitions.length
             if (totalItems > 0) {
               saveProject()
+            } else {
+              deleteProject(project._id)
             }
             navigate('/new')
           }}>

--- a/frontend/src/hooks/useAutosaveProject.ts
+++ b/frontend/src/hooks/useAutosaveProject.ts
@@ -1,9 +1,10 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 import { useProjectsStore, useProjectStore } from '/src/stores'
 import dayjs from 'dayjs'
 
 const SAVE_INTERVAL = 5 * 1000
+const SAVE_DIALOG_MIN_TIME = 1.5 * 1000
 
 /**
  * Use this to save the project on an interval. The project will only save if there are changes
@@ -15,6 +16,7 @@ const useAutosaveProject = () => {
   const lastChangeDate = useProjectStore(s => s.lastChangeDate)
   const lastSaveDate = useProjectStore(s => s.lastSaveDate)
   const setLastSaveDate = useProjectStore(s => s.setLastSaveDate)
+  const [isSaving, setIsSaving] = useState(false)
 
   useEffect(() => {
     const timer = setInterval(() => {
@@ -22,13 +24,21 @@ const useAutosaveProject = () => {
       const totalItems = currP.comments.length + currP.states.length + currP.transitions.length
       // Only save if there has been a change and there is something in the project
       if ((!lastSaveDate || dayjs(lastChangeDate).isAfter(lastSaveDate)) && totalItems > 0) {
+        setIsSaving(true)
         const toSave = { ...currP, meta: { ...currP.meta, dateEdited: new Date().getTime() } }
         upsertProject(toSave)
         setLastSaveDate(new Date().getTime())
+        // Hide "Saving..." dialog after a short delay
+        setTimeout(() => {
+          setIsSaving(false)
+        }, SAVE_DIALOG_MIN_TIME)
       }
     }, SAVE_INTERVAL)
+
     return () => clearInterval(timer)
-  })
+  }, [lastChangeDate, lastSaveDate, upsertProject, setLastSaveDate])
+
+  return isSaving
 }
 
 export default useAutosaveProject

--- a/frontend/src/hooks/useImageExport.ts
+++ b/frontend/src/hooks/useImageExport.ts
@@ -58,6 +58,9 @@ export const getSvgString = ({
 }: GetSvgStringProps = {}) => {
   // Clone the SVG element
   const svgElement = document.querySelector(`#${svgElementTag}`) as SVGGraphicsElement
+  if (svgElement === null) {
+    return { svg: null, height: 0, width: 0 }
+  }
   const clonedSvgElement = svgElement.cloneNode(true) as SVGGraphicsElement
 
   // Set viewbox
@@ -134,6 +137,7 @@ const useImageExport = () => {
 
     // Get the svg string
     const { svg, height, width } = getSvgString()
+    if (svg === null) return
 
     // Quick export SVG
     if (e.detail?.type === 'svg') {
@@ -166,8 +170,12 @@ const useImageExport = () => {
     window.setTimeout(() => {
       const { svg: svgLight } = getSvgString({ darkMode: false })
       const { svg: svgDark } = getSvgString({ darkMode: true })
-      setThumbnail(project._id, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
-      setThumbnail(`${project._id}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
+      if (svgLight !== null) {
+        setThumbnail(project._id, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
+      }
+      if (svgDark !== null) {
+        setThumbnail(`${project._id}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
+      }
     }, 200)
   }, [project])
 
@@ -175,8 +183,12 @@ const useImageExport = () => {
     window.setTimeout(() => {
       const { svg: svgLight } = getSvgString({ svgElementTag: 'selected-graph', darkMode: false })
       const { svg: svgDark } = getSvgString({ svgElementTag: 'selected-graph', darkMode: true })
-      setThumbnail(`tmp${e.detail}`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
-      setThumbnail(`tmp${e.detail}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
+      if (svgLight !== null) {
+        setThumbnail(`tmp${e.detail}`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgLight))
+      }
+      if (svgDark !== null) {
+        setThumbnail(`tmp${e.detail}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
+      }
       dispatchCustomEvent('selectionGraph:hide', null)
     }, 200)
   })

--- a/frontend/src/pages/Editor/Editor.tsx
+++ b/frontend/src/pages/Editor/Editor.tsx
@@ -47,7 +47,7 @@ const Editor = () => {
   const projectType = project.config.type
 
   // Auto save project as its edited
-  useAutosaveProject()
+  const isSaving = useAutosaveProject()
 
   // Register action hotkey
   useActions(true)
@@ -103,7 +103,7 @@ const Editor = () => {
 
   return (
     <>
-      <Menubar />
+      <Menubar isSaving={isSaving} />
       <Content>
         <Toolbar />
         <EditorContent>


### PR DESCRIPTION
Autosaving status message now displays correctly according to when it is happening as opposed to having to wait for an interval timeout.

Not sure how "reacty" this approach is, but I've fixed the issue by having our `useAutosaveProject` hook return a value corresponding to whether or not the project is currently being saved, and passing this state to our menu bar.

Fixes #259

| Original | Updated |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4e1f2a27-98b5-4048-b483-d888e9aacacb"> | <video src="https://github.com/user-attachments/assets/bda3e9ba-fd45-4d63-ab32-ba3990f173be"> |

The previous approach also seems to have had an issue with indefinitely displaying the spinner when updating a project to have nothing, i.e. deleting everything in it. When any state or comment is added back to the project, the spinner goes away. This issue is now fixed.

| Indefinite load |
| --- |
| <video src="https://github.com/user-attachments/assets/89360086-0dee-4008-a0d5-27ca014cd804"> |

