### PR TITLE
Properly use name from imported jff projects

### DIFF
--- a/frontend/src/hooks/useActions.ts
+++ b/frontend/src/hooks/useActions.ts
@@ -597,7 +597,7 @@ export const useParseFile = <T>(onData: (val: T) => void, errorMessage: string, 
         ...project,
         meta: {
           ...project.meta,
-          name: project.meta.name ?? input?.name.split('.').slice(0, -1).join('.')
+          name: project.meta.name || input?.name.split('.').slice(0, -1).join('.')
         }
       })
       onFinishLoading()


### PR DESCRIPTION
As part of the project importing code, we have a check to see if there is already a name that exists, and if it is a nullish value then use the fallback (the file name). The fallback value is never reached however because the project name (`project.meta.name`) would always be an empty string.

The fix is to simply use an `or` to fallback instead which shouldn't be an issue because we don't want an empty string or any other falsy values as name metadata in the first place

Fixes #504 
