### PR TITLE
feat: add Lucide icon to 'Add Question' button in modules (#526)

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -247,7 +247,7 @@ const Modules = () => {
                 ))}
               </tbody>
             </Table>
-            <Button onClick={handleAddQuestionClick}>+ Add question</Button>
+            <Button icon={<Plus/>} onClick={handleAddQuestionClick}>Add question</Button>
           </Wrapper>
           <Modal
             title="Select Question Type"


### PR DESCRIPTION
Closes #526 

-Description
Replaces the "+" string used for the "Add Question" button with a Lucide Plus icon for visual consistency, as same as in the templates panel.

Changes made in: frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx

-Issue Context
Currently, a plain "+" is used. For consistency, a Lucide icon is preferred (as used in the templates panel).

🙌 Additional Notes
This is my first open-source contribution — excited to get involved!
Please let me know if there's anything I should improve or change.