### PR TITLE
Update disabled button styling for module remove button

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/Modules/modulesStyle.ts
+++ b/frontend/src/components/Sidepanel/Panels/Modules/modulesStyle.ts
@@ -68,6 +68,10 @@ export const RemoveButton = styled('button')`
   align-items: center;
   justify-content: center;
   transition: background-color 0.3s;
+
+  &:disabled {
+    background-color: var(--disabled-button);
+  }
 `
 
 // Table header styles

--- a/frontend/src/components/Sidepanel/Panels/Modules/modulesStyle.ts
+++ b/frontend/src/components/Sidepanel/Panels/Modules/modulesStyle.ts
@@ -71,6 +71,7 @@ export const RemoveButton = styled('button')`
 
   &:disabled {
     background-color: var(--disabled-button);
+    cursor: default;
   }
 `
 


### PR DESCRIPTION
Closes #520 

This PR adds disabled button styling for the module remove question button to indicate that it is not clickable

| Original | Updated |
| --- | --- |
| <img width="378" alt="image" src="https://github.com/user-attachments/assets/1cfd67fb-2caa-4fb7-831a-f8ec92f22da4" /> | <img width="378" alt="image" src="https://github.com/user-attachments/assets/40c27696-ac5d-4de5-b873-9a21ff17fbc3" /> |
