### PR TITLE
feat: add confirmation dialog when deleting module questions (#521)

### DIFF
--- a/frontend/src/components/Modal/modalStyle.ts
+++ b/frontend/src/components/Modal/modalStyle.ts
@@ -63,6 +63,7 @@ export const Description = styled('span')`
   display: block;
   padding-inline: 1rem;
   opacity: .5;
+  margin-top: 0.5rem;
 `
 
 export const Buttons = styled('div')`

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -39,6 +39,10 @@ const Modules = () => {
 
   // Modal-related state management
   const [isModalOpen, setIsModalOpen] = useState(false) // Controls modal visibility
+  
+  // Delete confirmation modal state
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
+  const [projectToDelete, setProjectToDelete] = useState<ModuleProject | null>(null)
 
   // Load module values into local state when module changes
   useEffect(() => {
@@ -117,15 +121,31 @@ const Modules = () => {
     setProject(_project)
   }
 
+  // Show delete confirmation modal
   const handleDeleteQuestion = (_project: ModuleProject) => {
+    setProjectToDelete(_project)
+    setIsDeleteModalOpen(true)
+  }
+
+  // Perform actual deletion after confirmation
+  const confirmDeleteQuestion = () => {
+    if (!projectToDelete) return
+    
     // Delete project from current module
-    deleteProjectFromModule(_project._id)
+    deleteProjectFromModule(projectToDelete._id)
     // Delete question from current module
-    deleteQuestionFromModule(_project._id)
-    if (_project._id === currentProject._id) {
-      const remainingProjects = currentModule.projects.filter((proj) => proj._id !== _project._id)
+    deleteQuestionFromModule(projectToDelete._id)
+    
+    if (projectToDelete._id === currentProject._id && currentModule) {
+      const remainingProjects = currentModule.projects.filter((proj) => proj._id !== projectToDelete._id)
+  
       setProject(remainingProjects[0]) // Set the first remaining project as the current project
+      
     }
+    
+    // Close the modal and reset projectToDelete
+    setIsDeleteModalOpen(false)
+    setProjectToDelete(null)
   }
 
   // Drag and drop
@@ -236,12 +256,14 @@ const Modules = () => {
                     <td onClick={() => handleOpenQuestion(q)}>{`Question ${index + 1}`}</td>
                     <td>
                       <EditButton onClick={() => handleEditQuestion(q)}>Edit</EditButton>
-                      <RemoveButton
+                      
+
+                      {currentModule.projects.length > 1 && <RemoveButton
                         onClick={() => handleDeleteQuestion(q)}
-                        disabled={currentModule.projects.length <= 1}
                       >
                         Remove
-                      </RemoveButton>
+                      </RemoveButton> }
+                      
                     </td>
                   </tr>
                 ))}
@@ -249,6 +271,8 @@ const Modules = () => {
             </Table>
             <Button icon={<Plus/>} onClick={handleAddQuestionClick}>Add question</Button>
           </Wrapper>
+          
+          {/* Question Type Modal */}
           <Modal
             title="Select Question Type"
             description="Choose the type of question that you would like to add."
@@ -274,6 +298,31 @@ const Modules = () => {
               </FieldWrapper>
             </form>
           </Modal>
+          
+          {/* Delete Confirmation Modal */}
+          <Modal
+            title="Delete Question"
+            description="Are you sure you want to delete this question? This action cannot be undone."
+            isOpen={isDeleteModalOpen}
+            onClose={() => {
+              setIsDeleteModalOpen(false)
+              setProjectToDelete(null)
+            }}
+            actions={
+              <>
+                <Button 
+                  secondary 
+                  onClick={() => {
+                    setIsDeleteModalOpen(false)
+                    setProjectToDelete(null)
+                  }}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={confirmDeleteQuestion}>Delete</Button>
+              </>
+            }
+          />
         </>
         <SectionLabel>Export</SectionLabel>
         <Wrapper>

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -39,7 +39,7 @@ const Modules = () => {
 
   // Modal-related state management
   const [isModalOpen, setIsModalOpen] = useState(false) // Controls modal visibility
-  
+
   // Delete confirmation modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [projectToDelete, setProjectToDelete] = useState<ModuleProject | null>(null)
@@ -130,19 +130,18 @@ const Modules = () => {
   // Perform actual deletion after confirmation
   const confirmDeleteQuestion = () => {
     if (!projectToDelete) return
-    
+
     // Delete project from current module
     deleteProjectFromModule(projectToDelete._id)
     // Delete question from current module
     deleteQuestionFromModule(projectToDelete._id)
-    
+
     if (projectToDelete._id === currentProject._id && currentModule) {
       const remainingProjects = currentModule.projects.filter((proj) => proj._id !== projectToDelete._id)
-  
+
       setProject(remainingProjects[0]) // Set the first remaining project as the current project
-      
     }
-    
+
     // Close the modal and reset projectToDelete
     setIsDeleteModalOpen(false)
     setProjectToDelete(null)
@@ -256,14 +255,13 @@ const Modules = () => {
                     <td onClick={() => handleOpenQuestion(q)}>{`Question ${index + 1}`}</td>
                     <td>
                       <EditButton onClick={() => handleEditQuestion(q)}>Edit</EditButton>
-                      
 
                       {currentModule.projects.length > 1 && <RemoveButton
                         onClick={() => handleDeleteQuestion(q)}
                       >
                         Remove
                       </RemoveButton> }
-                      
+
                     </td>
                   </tr>
                 ))}
@@ -271,7 +269,7 @@ const Modules = () => {
             </Table>
             <Button icon={<Plus/>} onClick={handleAddQuestionClick}>Add question</Button>
           </Wrapper>
-          
+
           {/* Question Type Modal */}
           <Modal
             title="Select Question Type"
@@ -298,7 +296,7 @@ const Modules = () => {
               </FieldWrapper>
             </form>
           </Modal>
-          
+
           {/* Delete Confirmation Modal */}
           <Modal
             title="Delete Question"
@@ -310,8 +308,8 @@ const Modules = () => {
             }}
             actions={
               <>
-                <Button 
-                  secondary 
+                <Button
+                  secondary
                   onClick={() => {
                     setIsDeleteModalOpen(false)
                     setProjectToDelete(null)

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -39,7 +39,7 @@ const Modules = () => {
 
   // Modal-related state management
   const [isModalOpen, setIsModalOpen] = useState(false) // Controls modal visibility
-  
+
   // Delete confirmation modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [projectToDelete, setProjectToDelete] = useState<ModuleProject | null>(null)
@@ -130,19 +130,18 @@ const Modules = () => {
   // Perform actual deletion after confirmation
   const confirmDeleteQuestion = () => {
     if (!projectToDelete) return
-    
+
     // Delete project from current module
     deleteProjectFromModule(projectToDelete._id)
     // Delete question from current module
     deleteQuestionFromModule(projectToDelete._id)
-    
+
     if (projectToDelete._id === currentProject._id && currentModule) {
       const remainingProjects = currentModule.projects.filter((proj) => proj._id !== projectToDelete._id)
-  
+
       setProject(remainingProjects[0]) // Set the first remaining project as the current project
-      
     }
-    
+
     // Close the modal and reset projectToDelete
     setIsDeleteModalOpen(false)
     setProjectToDelete(null)
@@ -256,9 +255,7 @@ const Modules = () => {
                     <td onClick={() => handleOpenQuestion(q)}>{`Question ${index + 1}`}</td>
                     <td>
                       <EditButton onClick={() => handleEditQuestion(q)}>Edit</EditButton>
-                      
 
-                    
                       <RemoveButton
                         onClick={() => handleDeleteQuestion(q)}
                         disabled={currentModule.projects.length <= 1}
@@ -272,7 +269,7 @@ const Modules = () => {
             </Table>
             <Button icon={<Plus/>} onClick={handleAddQuestionClick}>Add question</Button>
           </Wrapper>
-          
+
           {/* Question Type Modal */}
           <Modal
             title="Select Question Type"
@@ -299,7 +296,7 @@ const Modules = () => {
               </FieldWrapper>
             </form>
           </Modal>
-          
+
           {/* Delete Confirmation Modal */}
           <Modal
             title="Delete Question"
@@ -311,8 +308,8 @@ const Modules = () => {
             }}
             actions={
               <>
-                <Button 
-                  secondary 
+                <Button
+                  secondary
                   onClick={() => {
                     setIsDeleteModalOpen(false)
                     setProjectToDelete(null)

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -39,7 +39,7 @@ const Modules = () => {
 
   // Modal-related state management
   const [isModalOpen, setIsModalOpen] = useState(false) // Controls modal visibility
-
+  
   // Delete confirmation modal state
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false)
   const [projectToDelete, setProjectToDelete] = useState<ModuleProject | null>(null)
@@ -130,18 +130,19 @@ const Modules = () => {
   // Perform actual deletion after confirmation
   const confirmDeleteQuestion = () => {
     if (!projectToDelete) return
-
+    
     // Delete project from current module
     deleteProjectFromModule(projectToDelete._id)
     // Delete question from current module
     deleteQuestionFromModule(projectToDelete._id)
-
+    
     if (projectToDelete._id === currentProject._id && currentModule) {
       const remainingProjects = currentModule.projects.filter((proj) => proj._id !== projectToDelete._id)
-
+  
       setProject(remainingProjects[0]) // Set the first remaining project as the current project
+      
     }
-
+    
     // Close the modal and reset projectToDelete
     setIsDeleteModalOpen(false)
     setProjectToDelete(null)
@@ -255,13 +256,15 @@ const Modules = () => {
                     <td onClick={() => handleOpenQuestion(q)}>{`Question ${index + 1}`}</td>
                     <td>
                       <EditButton onClick={() => handleEditQuestion(q)}>Edit</EditButton>
+                      
 
-                      {currentModule.projects.length > 1 && <RemoveButton
+                    
+                      <RemoveButton
                         onClick={() => handleDeleteQuestion(q)}
+                        disabled={currentModule.projects.length <= 1}
                       >
                         Remove
-                      </RemoveButton> }
-
+                      </RemoveButton>
                     </td>
                   </tr>
                 ))}
@@ -269,7 +272,7 @@ const Modules = () => {
             </Table>
             <Button icon={<Plus/>} onClick={handleAddQuestionClick}>Add question</Button>
           </Wrapper>
-
+          
           {/* Question Type Modal */}
           <Modal
             title="Select Question Type"
@@ -296,7 +299,7 @@ const Modules = () => {
               </FieldWrapper>
             </form>
           </Modal>
-
+          
           {/* Delete Confirmation Modal */}
           <Modal
             title="Delete Question"
@@ -308,8 +311,8 @@ const Modules = () => {
             }}
             actions={
               <>
-                <Button
-                  secondary
+                <Button 
+                  secondary 
                   onClick={() => {
                     setIsDeleteModalOpen(false)
                     setProjectToDelete(null)


### PR DESCRIPTION
Closes #521 

-Description
*Added confirmation modal when removing a question from a module
*Prevents accidental deletion of questions and their associated content
*When there is only a single question, there is no option given to remove

Changes made in: 
frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
frontend/src/components/Sidepanel/Panels/Modules/modalStyles.ts (added a small margin top for aesthetic purposes)

-Issue Context
In a module, when a user presses "Remove", there is no confirmation for the action that is performed. Since we don't want a user to lose their work, we should add confirmation before the deletion occurs


https://github.com/user-attachments/assets/72f018f9-aa29-46c1-8853-65fe3f8ce7f3




🙌 Additional Notes
Happy to contribute once more in this project :) . My second ever Open source contribution.