### PR TITLE
Refactor: remove duplicate enum from Modules.tsx and import from ProjectTypes

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -9,7 +9,7 @@ import { dispatchCustomEvent } from '/src/util/events'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 // Import enum from ProjectTypes
-import { ProjectType } from '../types/ProjectTypes'
+import { ProjectType } from '../../../../types/ProjectTypes'
 
 const Modules = () => {
   const setModuleProjects = useModuleStore(s => s.setProjects)

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -9,7 +9,7 @@ import { dispatchCustomEvent } from '/src/util/events'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 // Import enum from ProjectTypes
-import { ProjectType } from '../../../../types/ProjectTypes'
+import type { ProjectType } from '../../../../types/ProjectTypes'
 
 const Modules = () => {
   const setModuleProjects = useModuleStore(s => s.setProjects)

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -35,7 +35,7 @@ const Modules = () => {
   const [titleDescription, setTitleDescription] = useState('')
 
   const { register, handleSubmit } = useForm<{ questionType: ProjectType }>({
-  defaultValues: { questionType: 'FSA' },
+  defaultValues: { questionType: ProjectType.FSA },
 })
 
   // Modal-related state management

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -8,6 +8,8 @@ import { exportModuleFile } from '/src/hooks/useActions'
 import { dispatchCustomEvent } from '/src/util/events'
 import { Plus } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+// Import enum from ProjectTypes
+import { ProjectType } from '../types/ProjectTypes'
 
 const Modules = () => {
   const setModuleProjects = useModuleStore(s => s.setProjects)
@@ -32,12 +34,9 @@ const Modules = () => {
   const [titleInput, setTitleInput] = useState('')
   const [titleDescription, setTitleDescription] = useState('')
 
-  // enum for Project Types
-  enum ProjectType {
-    FSA = 'FSA',
-    PDA = 'PDA',
-    TM = 'TM',
-  }
+  const { register, handleSubmit } = useForm<{ questionType: ProjectType }>({
+  defaultValues: { questionType: 'FSA' },
+})
 
   // Modal-related state management
   const [isModalOpen, setIsModalOpen] = useState(false) // Controls modal visibility

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -90,8 +90,9 @@ const Modules = () => {
   }
 
   // Form handling using react-hook-form
-  const { register, handleSubmit } = useForm({ defaultValues: { questionType: 'FSA' } })
-
+  const { register, handleSubmit } = useForm<{ questionType: ProjectType }>({ 
+      defaultValues: { questionType: 'FSA' } 
+  })
   const handleAddQuestion = (data) => {
     const newModuleProject = createNewModuleProject(data.questionType, currentModule.meta.name)
     updateProjectToModule(newModuleProject) // Save new project with selected type

--- a/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Modules/Modules.tsx
@@ -34,10 +34,6 @@ const Modules = () => {
   const [titleInput, setTitleInput] = useState('')
   const [titleDescription, setTitleDescription] = useState('')
 
-  const { register, handleSubmit } = useForm<{ questionType: ProjectType }>({
-  defaultValues: { questionType: ProjectType.FSA },
-})
-
   // Modal-related state management
   const [isModalOpen, setIsModalOpen] = useState(false) // Controls modal visibility
 
@@ -94,7 +90,7 @@ const Modules = () => {
   }
 
   // Form handling using react-hook-form
-  const { register, handleSubmit } = useForm({ defaultValues: { questionType: ProjectType.FSA } })
+  const { register, handleSubmit } = useForm({ defaultValues: { questionType: 'FSA' } })
 
   const handleAddQuestion = (data) => {
     const newModuleProject = createNewModuleProject(data.questionType, currentModule.meta.name)


### PR DESCRIPTION
Closes issue #512

## Changes
- Removed existing enum in Modules.tsx
- Imported existing enum from ProjectTypes

## Testing
- Ran all tests: ✅ passed
- Verified Automatarium runs locally without errors.