### PR TITLE
Update tutorials manifest with new tutorials

### DIFF
--- a/frontend/src/config/tutorials-manifest.json
+++ b/frontend/src/config/tutorials-manifest.json
@@ -6,52 +6,60 @@
   "type": "section",
   "items": [
     {
-      "id": "fsa-walkthrough",
-      "title": "FSA Tutorial",
-      "blurb": "In this tutorial, learn how to create a Finite State Automaton in Automatarium.",
-      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p><p>Contact: <a href='mailto:automatarium.manager@gmail.com'>automatarium.manager@gmail.com</a></p><p>Voice: Russell from <a href='https://play.ht/'>https://play.ht/</a></p>",
-      "type": "item",
-      "link": "https://youtu.be/eYXXIuv-Joo"
-    },
-    {
-      "id": "pda-walkthrough",
-      "title": "PDA Tutorial",
-      "blurb": "In this tutorial, learn how to create a Pushdown Automaton in Automatarium.",
-      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p><p>Contact: <a href='mailto:automatarium.manager@gmail.com'>automatarium.manager@gmail.com</a></p><p>Voice: Russell from <a href='https://play.ht/'>https://play.ht/</a></p>",
-      "type": "item",
-      "link": "https://youtu.be/TMkRywWW_hs"
-    },
-    {
-      "id": "tm-walkthrough",
-      "title": "TM Tutorial",
-      "blurb": "In this tutorial, learn how to create a Turing Machine in Automatarium.",
-      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p><p>Contact: <a href='mailto:automatarium.manager@gmail.com'>automatarium.manager@gmail.com</a></p><p>Voice: Russell from <a href='https://play.ht/'>https://play.ht/</a></p>",
-      "type": "item",
-      "link": "https://youtu.be/kX0W6pmdTfo"
-    },
-    {
       "id": "creating-project-walkthrough",
       "title": "Getting Started",
       "blurb": "In this tutorial, learn how to create a project and customise your workspace in Automatarium.",
-      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p><p>Contact: <a href='mailto:automatarium.manager@gmail.com'>automatarium.manager@gmail.com</a></p><p>Voice: Russell from <a href='https://play.ht/'>https://play.ht/</a></p>",
+      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p>",
       "type": "item",
-      "link": "https://youtu.be/qrVVrJoZlrk"
+      "link": "https://youtu.be/BpCn5adYPEs"
     },
     {
       "id": "transitions-walkthrough",
       "title": "Transitions Tutorial",
       "blurb": "In this tutorial, learn how to manage transitions using Automatarium's unique features.",
-      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p><p>Contact: <a href='mailto:automatarium.manager@gmail.com'>automatarium.manager@gmail.com</a></p><p>Voice: Russell from <a href='https://play.ht/'>https://play.ht/</a></p>",
+      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p>",
       "type": "item",
-      "link": "https://youtu.be/RAoQh3z-Y0I"
+      "link": "https://youtu.be/ciRVwFgT1eg"
+    },
+    {
+      "id": "fsa-walkthrough",
+      "title": "FSA Tutorial",
+      "blurb": "In this tutorial, learn how to create a Finite State Automaton in Automatarium.",
+      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p>",
+      "type": "item",
+      "link": "https://youtu.be/kiG8RlEaaHw"
+    },
+    {
+      "id": "pda-walkthrough",
+      "title": "PDA Tutorial",
+      "blurb": "In this tutorial, learn how to create a Pushdown Automaton in Automatarium.",
+      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p>",
+      "type": "item",
+      "link": "https://youtu.be/ZPbuYOLs2QA"
+    },
+    {
+      "id": "tm-walkthrough",
+      "title": "TM Tutorial",
+      "blurb": "In this tutorial, learn how to create a Turing Machine in Automatarium.",
+      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p>",
+      "type": "item",
+      "link": "https://youtu.be/Hg2APtqHlTk"
     },
     {
       "id": "template-walkthrough",
       "title": "Templates Tutorial",
       "blurb": "In this tutorial, learn how to use templates in Automatarium.",
-      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p><p>Contact: <a href='mailto:automatarium.manager@gmail.com'>automatarium.manager@gmail.com</a></p><p>Voice: Russell from <a href='https://play.ht/'>https://play.ht/</a></p>",
+      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p>",
       "type": "item",
-      "link": "https://youtu.be/m6wTSj7-Oe0"
+      "link": "https://youtu.be/lCQb5q-DVU0"
+    },
+    {
+      "id": "module-walkthrough",
+      "title": "Modules Tutorial",
+      "blurb": "In this tutorial, learn how to use modules in Automatarium.",
+      "description": "<p>GitHub: <a href='https://github.com/automatarium/automatarium'>https://github.com/automatarium/automatarium</a></p>",
+      "type": "item",
+      "link": "https://youtu.be/mjEWi34XD3c"
     }
   ]
 }


### PR DESCRIPTION
Closes #547

- The updated tutorials created by Group 7 are now published on the RMIT Library youtube channel.
- The tutorials manifest has been updated to point to the new tutorials. 
- "Contact:" and "Voice:" relating to the old tutorials have removed from the description field.