### PR TITLE
Fix thumbnails using wrong theme with `system` theme

### DIFF
--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -35,7 +35,7 @@ const Templates = () => {
   const thumbs = useThumbnailStore(s => s.thumbnails)
 
   const theme = usePreferencesStore(state => state.getTheme())
-    const getThumbTheme = useCallback((id: string) => {
+  const getThumbTheme = useCallback((id: string) => {
       const thumbTheme = theme === 'dark' ? '-dark' : ''
       return `tmp${id}${thumbTheme}`
   }, [theme])

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -38,8 +38,7 @@ const Templates = () => {
     const getThumbTheme = useCallback((id: string) => {
       const thumbTheme = theme === 'dark' ? '-dark' : ''
       return `tmp${id}${thumbTheme}`
-    }, [theme])
-
+  }, [theme])
 
   const [templateNameInput, setTemplateNameInput] = useState('')
   const [error, setError] = useState('')

--- a/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
+++ b/frontend/src/components/Sidepanel/Panels/Templates/Templates.tsx
@@ -33,14 +33,13 @@ const Templates = () => {
   const { t } = useTranslation('common')
 
   const thumbs = useThumbnailStore(s => s.thumbnails)
-  const theme = usePreferencesStore(s => s.preferences).theme
 
-  const getThumbTheme = useCallback((id: string) => {
-    const thumbTheme = theme === 'system'
-      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? '-dark' : ''
-      : theme === 'dark' ? '-dark' : ''
-    return `tmp${id}${thumbTheme}`
-  }, [theme])
+  const theme = usePreferencesStore(state => state.getTheme())
+    const getThumbTheme = useCallback((id: string) => {
+      const thumbTheme = theme === 'dark' ? '-dark' : ''
+      return `tmp${id}${thumbTheme}`
+    }, [theme])
+
 
   const [templateNameInput, setTemplateNameInput] = useState('')
   const [error, setError] = useState('')

--- a/frontend/src/hooks/useImageExport.ts
+++ b/frontend/src/hooks/useImageExport.ts
@@ -167,7 +167,7 @@ const useImageExport = () => {
 
   // Generate project thumbnail
   useEffect(() => {
-    window.setTimeout(() => {
+    const id = window.setTimeout(() => {
       const { svg: svgLight } = getSvgString({ darkMode: false })
       const { svg: svgDark } = getSvgString({ darkMode: true })
       if (svgLight !== null) {
@@ -177,10 +177,11 @@ const useImageExport = () => {
         setThumbnail(`${project._id}-dark`, 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent('<?xml version="1.0" standalone="no"?>\r\n' + svgDark))
       }
     }, 200)
+    return () => window.clearTimeout(id)
   }, [project])
 
   useEvent('storeTemplateThumbnail', e => {
-    window.setTimeout(() => {
+    const id = window.setTimeout(() => {
       const { svg: svgLight } = getSvgString({ svgElementTag: 'selected-graph', darkMode: false })
       const { svg: svgDark } = getSvgString({ svgElementTag: 'selected-graph', darkMode: true })
       if (svgLight !== null) {
@@ -191,6 +192,7 @@ const useImageExport = () => {
       }
       dispatchCustomEvent('selectionGraph:hide', null)
     }, 200)
+    return () => window.clearTimeout(id)
   })
 }
 

--- a/frontend/src/pages/NewFile/NewFile.tsx
+++ b/frontend/src/pages/NewFile/NewFile.tsx
@@ -29,6 +29,8 @@ const NewFile = () => {
   const thumbnails = useThumbnailStore(s => s.thumbnails)
   const removeThumbnail = useThumbnailStore(s => s.removeThumbnail)
   const preferences = usePreferencesStore(state => state.preferences)
+  const theme = usePreferencesStore(state => state.getTheme())
+
   // We find the tallest card using method shown here
   // https://legacy.reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node
   const [height, setHeight] = useState(0)
@@ -87,16 +89,14 @@ const NewFile = () => {
   // Dynamic styling values for new project thumbnails
   // Will likely be extended to 'Your Projects' list
   // If matching system theme, don't append a theme to css vars
-  const theme = preferences.theme === 'system' ? '' : `-${preferences.theme}`
+  const cssTheme = preferences.theme === 'system' ? '' : `-${preferences.theme}`
   const getThumbTheme = useCallback((id: string) => {
-    const thumbTheme = preferences.theme === 'system'
-      ? window.matchMedia && window.matchMedia('prefer-color-scheme: dark').matches ? '-dark' : ''
-      : preferences.theme === 'dark' ? '-dark' : ''
+    const thumbTheme = theme === 'dark' ? '-dark' : ''
     return `${id}${thumbTheme}`
-  }, [preferences.theme])
+  }, [theme])
   const stylingVals = {
-    stateFill: `var(--state-bg${theme})`,
-    strokeColor: `var(--stroke${theme})`
+    stateFill: `var(--state-bg${cssTheme})`,
+    strokeColor: `var(--stroke${cssTheme})`
   }
 
   // Remove old thumbnails

--- a/frontend/src/stores/usePreferencesStore.ts
+++ b/frontend/src/stores/usePreferencesStore.ts
@@ -15,6 +15,10 @@ export interface Preferences {
 interface PreferencesStore {
   preferences: Preferences
   setPreferences: (preferences: Preferences) => void
+  /**
+  * Gets the current selected theme. Resolves system theme if the user has "system" selected
+  */
+  getTheme: () => 'light' | 'dark'
 }
 
 const defaultPreferences: Preferences = {
@@ -26,9 +30,15 @@ const defaultPreferences: Preferences = {
   language: 'en'
 }
 
-const usePreferencesStore = create<PreferencesStore>()(persist((set: SetState<PreferencesStore>) => ({
+const usePreferencesStore = create<PreferencesStore>()(persist((set: SetState<PreferencesStore>, get) => ({
   preferences: { ...defaultPreferences },
-  setPreferences: (preferences: Preferences) => set({ preferences })
+  setPreferences: (preferences: Preferences) => set({ preferences }),
+  getTheme: () => {
+    const theme = get().preferences.theme
+    return theme === 'system'
+          ? window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+          : theme
+  }
 }), {
   name: 'automatarium-preferences'
 }))


### PR DESCRIPTION
The CSS before was `prefer-color-scheme: dark` when it should be `(prefers-color-scheme: dark)` which lead to it never matching and always using light theme when user had system theme selected.

Also fixed the debouncing code which wasn't properly clearing the last timeout, small optimisation

**Before**
<img width="392" height="351" alt="image" src="https://github.com/user-attachments/assets/b997c36d-5607-40e9-bf90-e2c031f15944" />


**After**
<img width="938" height="324" alt="image" src="https://github.com/user-attachments/assets/40310fe5-57a9-4b68-a2eb-b559167c7559" />
