### PR TITLE
Only run on push to mainline branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,9 @@
 name: CI tests
 on: 
   push:
+    branches:
+      - dev
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
Noticed in a PR that the CI was running twice for pull requests. Now it will only run on pushes to dev/main branch (Will still run for commits on PRs)