### PR TITLE
Add a `#` to make the shared URL work with the hash router

### DIFF
--- a/frontend/src/components/ShareUrl/ShareUrl.tsx
+++ b/frontend/src/components/ShareUrl/ShareUrl.tsx
@@ -15,7 +15,7 @@ const ShareUrl = () => {
 
   const [base64Project, setBase64Project] = useState('')
 
-  const shareRawLink = `${window.location.origin}/share/raw/${base64Project}`
+  const shareRawLink = `${window.location.origin}#/share/raw/${base64Project}`
 
   const [exportUrlOpen, setExportUrlOpen] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)

--- a/frontend/src/components/ShareUrlModule/ShareUrlModule.tsx
+++ b/frontend/src/components/ShareUrlModule/ShareUrlModule.tsx
@@ -15,7 +15,7 @@ const ShareUrlModule = () => {
 
   const [base64Project, setBase64Project] = useState('')
 
-  const shareRawLink = `${window.location.origin}/share/module/${base64Project}`
+  const shareRawLink = `${window.location.origin}#/share/module/${base64Project}`
 
   const [exportUrlOpen, setExportUrlOpen] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)


### PR DESCRIPTION
Fixes #596, needs a `#` to make the link work with hash router.

Evidence
<img width="500" height="200" alt="image" src="https://github.com/user-attachments/assets/8d1bbeaa-837f-46cf-9336-5bc0e59f04b5" />

[Link here](https://automatarium-frontend-git-fix-sharing-automatarium.vercel.app#/share/raw/H4sIAAAAAAAAA1WQsUrDUBSGE8HHEBwcXCrVxraOIhacFKviJic3J+mV5N5674lYcJLWwanFzcm0aauNg+gb6CaKs2_jjYjU9Ts___9xrrKmksfIaK_VxEGtvj444t7XQhlWVqtOaa3glJlfcFZLXgHAqRZWfNerVthaqeI6I01AqK_bydmHfZm0Puy5PvesMdc1LiB8yfnMVtJ6fzXY_o8P83jD8Jk_npECoTlxKXSvnfpKRlafpJ13pgrBS+COyShCQbp7r3m0izoOqTs0DqQvRpqLIMTboQvEGr3bBy5MF4T1XNJKIyTopAIifFwPFCK4Ic7vm8VYZ55JbJgFQu_Tsuybt0V3dpLDTY9Ps_EpKm30hstLxaXiM8QkIyBQPI4Opi8jJoXPg05Kvz_Nfj61o9DnZ8nJRKrtJiogqZLzJ2AMmwSCGQWzpjikrqTGkMlQqpE0hgF+A6HVlK+lAQAA)