### PR TITLE
fix(editor): enable keybindings in standard editor

### DIFF
--- a/frontend/src/pages/Editor/Editor.tsx
+++ b/frontend/src/pages/Editor/Editor.tsx
@@ -12,7 +12,7 @@ import { useEditorControls } from "../../hooks/useEditorControls";
 import { useModuleValidation } from "../../hooks/useModuleValidation";
 import { EditorUIProvider, useEditorUI } from "../../providers/EditorUIProvider";
 import { usePanelWidth } from "@/hooks/usePanelWidth";
-import { useEvent } from "/src/hooks"
+import { useActions, useEvent } from "/src/hooks"
 
 
 
@@ -38,6 +38,7 @@ function Editor() {
   useEditorInit();
   useEditorControls();
   useModuleValidation();
+  useActions(true);
 
   // Listen to the custom event 'tour:start' to show the tour
   useEvent('tour:start', () => {


### PR DESCRIPTION
Closes #597 

This PR Fixes keybindings not working for projects opened from New Project/New Module flows.

Changes:

Registers action hotkeys in standard editor `useActions(true)` to match Automata Examples behavior.
Minimal, targeted fix addressing only the specific issue
Testing:

✅ keybindings now work