### PR TITLE
fix(share-url): update shareRawLink to use window.location.href

### DIFF
--- a/frontend/src/components/ShareUrl/ShareUrl.tsx
+++ b/frontend/src/components/ShareUrl/ShareUrl.tsx
@@ -15,7 +15,7 @@ const ShareUrl = () => {
 
   const [base64Project, setBase64Project] = useState('')
 
-  const shareRawLink = `${window.location.origin}#/share/raw/${base64Project}`
+  const shareRawLink = `${window.location.href.split('#')[0]}#/share/raw/${base64Project}`
 
   const [exportUrlOpen, setExportUrlOpen] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)

--- a/frontend/src/components/ShareUrlModule/ShareUrlModule.tsx
+++ b/frontend/src/components/ShareUrlModule/ShareUrlModule.tsx
@@ -15,7 +15,7 @@ const ShareUrlModule = () => {
 
   const [base64Project, setBase64Project] = useState('')
 
-  const shareRawLink = `${window.location.origin}#/share/module/${base64Project}`
+  const shareRawLink = `${window.location.href.split('#')[0]}#/share/module/${base64Project}`
 
   const [exportUrlOpen, setExportUrlOpen] = useState(false)
   const [copySuccess, setCopySuccess] = useState(false)


### PR DESCRIPTION
Closes #602 

This PR fixes the share of feature on github deployment

Changes:

Updated project share link generation to keep the current pre-hash base path.
Minimal, targeted fix addressing only the GitHub Pages share URL issue.
Testing:

✅ On GitHub Pages, copied share links should now include /automatarium/<branch>/#/share/... and open correctly.
✅ Local development share links still work.